### PR TITLE
Fix mavlink-router startup script serial device path autodetection

### DIFF
--- a/platform/common/scripts/start_mavlink_router.sh
+++ b/platform/common/scripts/start_mavlink_router.sh
@@ -11,8 +11,8 @@ if [ -z "$DEVICE_PATH" ]; then
     exit 1
 fi
 
-# Update the main.conf file with the correct device path for FCUSB
-sed -i "s|^Device =.*|Device = $DEVICE_PATH|" "$MAVLINK_ROUTERD_CONF_FILE"
+# Replace serial device "*if00" with correct device path for PX4/Ardupilot
+sed -i "s|^Device =.*if00|Device = $DEVICE_PATH|" "$MAVLINK_ROUTERD_CONF_FILE"
 
 # Enable mavlink usb stream first
 python3 ~/.local/bin/vbus_enable.py


### PR DESCRIPTION
Fixes issue where the `start_mavlink_router.sh` script will change all UART `Device` paths to the FC USB path.