### PR TITLE
Example GPIO control on I2S connector

### DIFF
--- a/platform/jetson/scripts/i2s_gpio_example.py
+++ b/platform/jetson/scripts/i2s_gpio_example.py
@@ -1,22 +1,18 @@
 #!/usr/bin/env python
 
-# Script to demonstrate I2S GPIO functionality on Jetson Orin
+# Script to demonstrate I2S GPIO functionality on ARK Jetson Carrier
 # Uses I2S0_DOUT as output and I2S0_DIN as input
 # Requires physical connection between pin 40 (DOUT) and pin 38 (DIN)
 
 import Jetson.GPIO as GPIO
 import time
 
-# Pin Definitions - using the Jetson Board Pin numbers
 output_pin = 40  # I2S0_DOUT - Header pin 40
 input_pin = 38   # I2S0_DIN - Header pin 38
 
 def main():
-    # Pin Setup:
     GPIO.setmode(GPIO.BOARD)  # Jetson board numbering scheme
-    # Set pin 40 as output with initial state of HIGH
     GPIO.setup(output_pin, GPIO.OUT, initial=GPIO.HIGH)
-    # Set pin 38 as input
     GPIO.setup(input_pin, GPIO.IN)
 
     print("Starting I2S GPIO test. Press CTRL+C to exit")
@@ -26,24 +22,19 @@ def main():
 
     try:
         while True:
-            # Toggle the output pin value
             GPIO.output(output_pin, curr_output_value)
             print(f"Output pin {output_pin} set to: {curr_output_value}")
 
-            # Read the input pin value
             input_value = GPIO.input(input_pin)
             print(f"Input pin {input_pin} read as: {input_value}")
 
-            # Verify if input matches output
             if input_value == curr_output_value:
                 print("SUCCESS: Input matches output")
             else:
                 print("FAILURE: Input doesn't match output")
 
-            # Toggle the value for next iteration
             curr_output_value = GPIO.LOW if curr_output_value == GPIO.HIGH else GPIO.HIGH
 
-            # Wait before next toggle
             time.sleep(1)
             print("--------------------------")
 

--- a/platform/jetson/scripts/i2s_gpio_example.py
+++ b/platform/jetson/scripts/i2s_gpio_example.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+# Script to demonstrate I2S GPIO functionality on Jetson Orin
+# Uses I2S0_DOUT as output and I2S0_DIN as input
+# Requires physical connection between pin 40 (DOUT) and pin 38 (DIN)
+
+import Jetson.GPIO as GPIO
+import time
+
+# Pin Definitions - using the Jetson Board Pin numbers
+output_pin = 40  # I2S0_DOUT - Header pin 40
+input_pin = 38   # I2S0_DIN - Header pin 38
+
+def main():
+    # Pin Setup:
+    GPIO.setmode(GPIO.BOARD)  # Jetson board numbering scheme
+    # Set pin 40 as output with initial state of HIGH
+    GPIO.setup(output_pin, GPIO.OUT, initial=GPIO.HIGH)
+    # Set pin 38 as input
+    GPIO.setup(input_pin, GPIO.IN)
+
+    print("Starting I2S GPIO test. Press CTRL+C to exit")
+    print("Make sure pins 40 (DOUT) and 38 (DIN) are connected together")
+
+    curr_output_value = GPIO.HIGH
+
+    try:
+        while True:
+            # Toggle the output pin value
+            GPIO.output(output_pin, curr_output_value)
+            print(f"Output pin {output_pin} set to: {curr_output_value}")
+
+            # Read the input pin value
+            input_value = GPIO.input(input_pin)
+            print(f"Input pin {input_pin} read as: {input_value}")
+
+            # Verify if input matches output
+            if input_value == curr_output_value:
+                print("SUCCESS: Input matches output")
+            else:
+                print("FAILURE: Input doesn't match output")
+
+            # Toggle the value for next iteration
+            curr_output_value = GPIO.LOW if curr_output_value == GPIO.HIGH else GPIO.HIGH
+
+            # Wait before next toggle
+            time.sleep(1)
+            print("--------------------------")
+
+    except KeyboardInterrupt:
+        print("\nExiting program")
+    finally:
+        GPIO.cleanup()
+        print("GPIO pins cleaned up")
+
+if __name__ == '__main__':
+    main()

--- a/setup/install_software.sh
+++ b/setup/install_software.sh
@@ -194,7 +194,7 @@ if [ "$TARGET" = "jetson" ]; then
 	sudo apt-get install libqmi-utils -y
 
 	sudo pip3 install \
-		Jetson.GPIO \
+		'Jetson.GPIO>=2.1.9' \
 		smbus2 \
 		meson \
 		pyserial \


### PR DESCRIPTION
Adds an example script for using the I2S0 connector for GPIO control. The example uses I2S0_DOUT as the output pin and I2S0_DIN as the input pin. To validate this example please connect these two pins together with a jumper wire.

First enable the overlay and reboot.
```
sudo /opt/nvidia/jetson-io/config-by-hardware.py -n 1="ARK I2S to GPIO"
sudo reboot
```

Ensure Jetson.GPIO is up to date
```
pip3 install 'Jetson.GPIO>=2.1.9'
```

Run the example
```
python3 i2s_gpio_example.py
```
```
Output pin 40 set to: 1
Input pin 38 read as: 1
SUCCESS: Input matches output
--------------------------
Output pin 40 set to: 0
Input pin 38 read as: 0
SUCCESS: Input matches output
--------------------------
```