### PR TITLE
autopilot-manager: periodically send SYSTEM_TIME

### DIFF
--- a/services/autopilot-manager/autopilot_manager.py
+++ b/services/autopilot-manager/autopilot_manager.py
@@ -155,9 +155,8 @@ class MAVLinkConnection:
 
         try:
             logger.info(f"Sending system time {int(current_time * 1e6)}")
-            # TODO: fill with proper UTC timestamp
             time_unix_usec = int(current_time * 1e6);
-            time_boot_ms = 0;
+            time_boot_ms = 0; # unused in PX4
             self.mav_connection.mav.system_time_send(
                 time_unix_usec,
                 time_boot_ms


### PR DESCRIPTION
Mechanism to update PX4 system clock. On platforms without GPS (dexi) the system time can be days/weeks old depending on when you last flew with GPS. This makes it hard to keep track of logs. This PRsends out the SYSTEM_TIME message every 5 seconds to ensure PX4 clock is updated. 

It doesn't need to be periodic but rather everytime PX4 is power cycled, periodic is simple and harmless, the only side effect is every 5 seconds on PX4 side the `px4_clock_gettime()` function is called in the mavlink handler.