### PR TITLE
dds-agent: build from source, snap can't access uarts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "submodules/rtsp-server"]
 	path = services/rtsp-server/rtsp-server
 	url = https://github.com/ARK-Electronics/rtsp-server.git
+[submodule "services/dds-agent/Micro-XRCE-DDS-Agent"]
+	path = services/dds-agent/Micro-XRCE-DDS-Agent
+	url = https://github.com/eProsima/Micro-XRCE-DDS-Agent.git

--- a/services/dds-agent/dds-agent.service
+++ b/services/dds-agent/dds-agent.service
@@ -8,7 +8,6 @@ Type=simple
 ExecStart=%h/.local/bin/start_dds_agent.sh
 Restart=on-failure
 RestartSec=5
-# Add a slight delay to ensure devices are fully initialized
 ExecStartPre=/bin/sleep 2
 
 [Install]

--- a/services/dds-agent/install_dds_agent.sh
+++ b/services/dds-agent/install_dds_agent.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 echo "Installing micro-xrce-dds-agent"
-sudo snap install micro-xrce-dds-agent --edge
+pushd .
+cd Micro-XRCE-DDS-Agent
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+popd

--- a/services/dds-agent/start_dds_agent.sh
+++ b/services/dds-agent/start_dds_agent.sh
@@ -33,16 +33,15 @@ echo "Detected platform: $TARGET"
 case "$TARGET" in
     jetson)
         echo "Starting DDS agent for Jetson platform"
-        exec /snap/bin/micro-xrce-dds-agent serial -b 3000000 -D /dev/ttyTHS1
+        exec MicroXRCEAgent serial -b 3000000 -D /dev/ttyTHS1
         ;;
     pi)
         echo "Starting DDS agent for Raspberry Pi platform"
-        exec /snap/bin/micro-xrce-dds-agent serial -b 3000000 -D /dev/ttyAMA4
+        exec MicroXRCEAgent serial -b 3000000 -D /dev/ttyAMA4
         ;;
     ubuntu)
         echo "Starting DDS agent for Ubuntu desktop"
-        # For Ubuntu, use UDP on port 8888
-        exec /snap/bin/micro-xrce-dds-agent udp4 -p 8888
+        exec MicroXRCEAgent udp4 -p 8888
         ;;
     *)
         echo "Unknown platform"


### PR DESCRIPTION
Fixes permission errors with dds-agent. Apparently it is not possible to give snap packages access to UARTs. Why does snap suck so bad?