### PR TITLE
Add CPU scheduling parameters to logloader

### DIFF
--- a/services/logloader/logloader.service
+++ b/services/logloader/logloader.service
@@ -9,9 +9,6 @@ Environment=SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ExecStart=%h/.local/bin/logloader
 Restart=always
 RestartSec=5
-# Log download drives MAVSDK to call refresh_timeout_handler ~3750x/sec
-# causing ~95% CPU. Lower scheduling priority so flight-critical services
-# (mavlink-router, autopilot-manager) are not starved during downloads.
 Nice=10
 CPUWeight=50
 

--- a/services/logloader/logloader.service
+++ b/services/logloader/logloader.service
@@ -9,6 +9,11 @@ Environment=SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ExecStart=%h/.local/bin/logloader
 Restart=always
 RestartSec=5
+# Log download drives MAVSDK to call refresh_timeout_handler ~3750x/sec
+# causing ~95% CPU. Lower scheduling priority so flight-critical services
+# (mavlink-router, autopilot-manager) are not starved during downloads.
+Nice=10
+CPUWeight=50
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
This falls out of the dicussion around CPU load issues with logloader on newer mavsdk releases. The problem does not occur with mavsdk 3.10.2

Julians AI assessment
```
 Primary cause: Eager check_and_request_missing_bins() in the hot path (log_files_impl.cpp:458-470)

 After commit 01ea24fe3, every arriving LOG_DATA message where the last bin has already been received triggers check_and_request_missing_bins(), which sends
 a new LOG_REQUEST_DATA message. With UDP, bins can arrive slightly out of order. If bin 127 arrives before some earlier bins, every subsequent arriving bin
 triggers a redundant re-request. This creates cascading effects:

 1. Each re-request causes the autopilot to resend data → duplicate messages
 2. Each outgoing LOG_REQUEST_DATA goes through expensive deliver_message() path (libmav parse + JSON generation)
 3. Each incoming duplicate LOG_DATA goes through expensive LibmavReceiver path (libmav parse + JSON generation)
 4. The duplicate data triggers more re-requests, amplifying the cascade

 Secondary cause: TABLE_BINS reduced from 512 to 128 (log_files_impl.h)

 Commit b73da2550 reduced chunk size from 46,080 to 11,520 bytes. This means 4x more chunk transitions per file, and the eager re-request problem happens 4x
 more often.

 Minor cause: O(n) completion check (log_files_impl.cpp:419-422)
 ```