### PR TITLE
BUGFIX: Close jtop socket after SystemInfo poll

### DIFF
--- a/services/system-manager/system_manager.py
+++ b/services/system-manager/system_manager.py
@@ -117,7 +117,7 @@ class JetsonCollector(SystemInfoCollector):
 
             with jtop() as jetson:
                 if not jetson.ok():
-                    return None
+                    raise RuntimeError("Jtop is not OK")
 
                 # Collect all temperature data
                 temperatures = {}
@@ -162,12 +162,15 @@ class JetsonCollector(SystemInfoCollector):
                     }
                 }
 
-                return data
+                return_data = data
         except (ImportError, ModuleNotFoundError):
-            return None
+            return_data = None
         except Exception as e:
             print(f"Error collecting Jetson data: {e}")
-            return None
+            return_data = None
+        finally:
+            jetson.close()
+            return return_data
 
 
 class RaspberryPiCollector(SystemInfoCollector):


### PR DESCRIPTION
First PR, lmk if I can format more helpfully or provide more testing or logs. Good news is that this is readily reproducible. 

# User Impact

If one leaves the SystemPage for ARK-OS up for more than a day (more likely in a development context of course than configuration-for-flight), eventually the SystemPage gets stuck loading and never recovers. It requires at minimum a reboot of the system_manager backend service to be able to run again. 

## Technical Details

The cause of this issue is an interaction between the frequent (every few seconds) polling of the api/system/info backend endpoint and the system_manager.py backend's use of `jtop` python package. I did an `strace -p <pid>` of the running system manager for a while while it was struggling to load and the issue that jumped out was `EMFILE` (Too many open files).

Every few seconds the systemInfo UI calls the python backend service to poll jetson information via jtop, but then it doesn't close the socket. 

This issue only occurs when I leave the SystemPage selected, and only on a Jetson platform which invokes `jtop`.


### Reproducing the Issue

* Install ARK-OS on a Jetson-based target (ideally ARK Jetson PAB Carrier hosting a Jetson Orin Nano)
* Navigate to the Jetson-based target's IP or FQDN and leave the SystemPage selected in a browser
* find the PID for system_manager.py by running `ps aux | grep system_manager.py`
* now call `watch -n1 "lsof -p <PID> | grep type=STREAM"` using the PID you just found
    *You can also just use `watch -n1 "lsof -p <PID> | grep type=STREAM | wc -l"` to get a count of FDs rather than details
* **If this increases every few seconds, the bug is occurring. If the count of UDS stays roughly around 3 the bug is not occurring. It's ok if some new entries appear for a few seconds then disappear.**
* To check the JTOP end of the socket, use `watch -n1 "ss -xa -f unix | grep jtop.sock"` to see if number of FDs are monotonically increasing
    * You can also use `watch -n1 "ss -xa -f unix | grep jtop.sock | wc -l"` to just count the instances of jtop.sock increasing


## Testing

I am able to reproduce this issue on a Jetson PAB Carrier and on a generic Jetson Orin Nano SuperDevKit. 

After the change below, the number of FDs does not increase and the SystemPage works indefinitely. 