### PR TITLE
Fix install script failures: SCRIPT_DIR collision, dpkg lock, node version

### DIFF
--- a/services/ark-ui-backend/start_ark_ui_backend.sh
+++ b/services/ark-ui-backend/start_ark_ui_backend.sh
@@ -4,7 +4,7 @@ export NVM_DIR="$HOME/.config/nvm"
 source $NVM_DIR/nvm.sh
 
 # Specify the Node version
-nvm use 20.15.0
+nvm use 20
 
 # Start your application
 cd /var/www/ark-ui/api

--- a/tools/functions.sh
+++ b/tools/functions.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 # Determine PROJECT_ROOT as one level up from this script's location
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-PROJECT_ROOT="$( cd "$SCRIPT_DIR/.." &> /dev/null && pwd )"
+# Use _FUNCTIONS_DIR to avoid clobbering the caller's SCRIPT_DIR variable
+_FUNCTIONS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_ROOT="$( cd "$_FUNCTIONS_DIR/.." &> /dev/null && pwd )"
+unset _FUNCTIONS_DIR
 
 # Export the PROJECT_ROOT variable so it's available to scripts that source this file
 export PROJECT_ROOT

--- a/tools/install_mavsdk.sh
+++ b/tools/install_mavsdk.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source "$SCRIPT_DIR/functions.sh"
+
 function git_clone_retry() {
 	local url="$1" dir="$2" branch="$3" retries=3 delay=5
 
@@ -62,12 +65,8 @@ if [ "$success" = true ]; then
 	echo "Downloading completed successfully."
 	echo "Installing $file_name"
 
-	for attempt in {1..5}; do
-		sudo dpkg -i "$file_name" && break || sleep 5
-	done
-
-	if [ $attempt -eq 5 ]; then
-		echo "Failed to install $file_name after 5 attempts."
+	if ! apt_get_install install -y --allow-downgrades "./$file_name"; then
+		echo "Failed to install $file_name"
 		exit 1
 	fi
 


### PR DESCRIPTION
## Summary
- **functions.sh** overwrites caller's `SCRIPT_DIR` when sourced, causing `frontend/ark-ui/install.sh` to `cd` into `tools/` instead of `frontend/ark-ui/` — `npm install` never runs, express module missing at runtime
- **install_mavsdk.sh** uses bare `sudo dpkg -i` which has no lock timeout — replaced with `apt_get_install` wrapper (`DPkg::Lock::Timeout=120`)
- **start_ark_ui_backend.sh** hardcodes `nvm use 20.15.0` but installer runs `nvm install 20` (gets latest 20.x) — changed to `nvm use 20`

## Test plan
- [ ] Run full install on Jetson and verify ark-ui-backend starts without express/node version errors
- [ ] Verify MAVSDK .deb installs successfully even when apt lock is briefly held

🤖 Generated with [Claude Code](https://claude.com/claude-code)