### PR TITLE
BUGFIX: Resolve connection-manager deadlock from stats_lock edgecase

### DIFF
--- a/services/connection-manager/connection_manager.py
+++ b/services/connection-manager/connection_manager.py
@@ -52,7 +52,12 @@ class State:
     interface_stats = {}  # Store the latest stats for each interface
     last_stats_update = 0
     last_stats_report = 0
-    stats_lock = threading.Lock()  # Thread safety for stats access
+
+    # Use a re-entrant lock so that the same StatsThread may
+    # re-acquire the same lock in get_interface_usage_summary() **and**
+    # method update_interface_stats() that it calls if no interface stats available
+    # on first go-round
+    stats_lock = threading.RLock()  # Thread safety for stats access
 
     # Websocket clients for real-time updates
     active_stats_clients = set()


### PR DESCRIPTION

# User Impact

My device gets in a state where the Data Usage just never works

Looking at journald for the service, I see this loop infinitely:

```bash
Mar 12 01:01:19 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:01:19,310 - connection-manager - INFO - Network stats client connected: yHN7koOnsxCMIgAIAAAB
Mar 12 01:01:19 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:01:19,310 - connection-manager - INFO - Client added. Total active clients: 1
Mar 12 01:01:19 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:01:19,311 - connection-manager - INFO - Stats thread started
Mar 12 01:01:53 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:01:53,734 - connection-manager - INFO - GET /connections called
Mar 12 01:01:54 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:01:54,550 - connection-manager - INFO - Network stats client connected: c3yLfDCSydj3Us9wAAAD
Mar 12 01:01:54 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:01:54,551 - connection-manager - INFO - Client added. Total active clients: 2
Mar 12 01:02:19 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:02:19,284 - connection-manager - INFO - Network stats client disconnected: yHN7koOnsxCMIgAIAAAB, reason: ping timeout
Mar 12 01:02:19 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:02:19,284 - connection-manager - INFO - Client removed. Remaining active clients: 1
Mar 12 01:02:35 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:02:35,368 - connection-manager - INFO - GET /connections called
Mar 12 01:02:38 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:02:38,375 - connection-manager - INFO - Network stats client connected: hk5uszrlShTMojiYAAAF
Mar 12 01:02:38 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:02:38,376 - connection-manager - INFO - Client added. Total active clients: 2
Mar 12 01:02:45 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:02:45,962 - connection-manager - INFO - Network stats client disconnected: c3yLfDCSydj3Us9wAAAD, reason: ping timeout
Mar 12 01:02:45 ark-jetson-devicelab-gps python3[568644]: 2026-03-12 01:02:45,963 - connection-manager - INFO - Client removed. Remaining active clients: 1
```

## Technical Details

Switch State.stats_lock from Lock() to RLock() as there is an edge case where the same thread attempts to recursively acquire the same lock in case of an initial condition (no interface stats by the time a statsThread spins up to return Data Usage). This seems to happen to me every time for reasons I am not yet sure. 

## Reproducing the Issue

I am not fully certain why this race condition is happening to me (and presumably not to everyone), but 
* if you can nudge  initial conditions such that you hit `get_interface_usage_summary()` before `interface_stats` has been populated, and thus 
* you go down the condition of L936 prior to the diff 
* Then the same thread that already has currently-non-reentrant `stats_lock` in `get_interface_usage_summary()` back up at L930 prior to the diff, tries to re-acquire the same `stats_lock` in `NetworkStatsProcessor.update_interface_usage()`, leading to a deadlock

## Suggested Fix

Looking at the intent and structure, it seems like using python's Threading RLock is a reasonable and surgical fix for the goals and assumptions of this service. 

## Testing

Setting log level to DEBUG and adding some instrumentation, I can see that before this change I spin on wanting the stats_lock:

```bash
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,499 - connection-manager - INFO - Client added. Total active clients: 1
# ...
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,504 - connection-manager - INFO - Stats thread started
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,504 - connection-manager - DEBUG - NetworkReport Wants stats lock
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,504 - connection-manager - DEBUG - NetworkReport Got stats lock
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,504 - connection-manager - DEBUG - No interface stats available, collecting now for 0 items
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,504 - connection-manager - DEBUG - Running command: nmcli -t -f NAME,TYPE,STATE connection show
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,566 - connection-manager - DEBUG - Running command: nmcli -g GENERAL.IP-IFACE connection show "Wired connection 1"
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,576 - connection-manager - DEBUG - Running command: nmcli -g GENERAL.IP-IFACE connection show "Wired connection 1"
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,634 - connection-manager - DEBUG - Connection 'Wired connection 1' using IP interface: enP8p1s0
# ...
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,804 - connection-manager - DEBUG - Found 4 active NetworkManager connections
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,804 - connection-manager - DEBUG - Running command: ip -s link show enP8p1s0
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,812 - connection-manager - DEBUG - Running command: ip addr show enP8p1s0 | grep -w inet | head -1 | awk '{print $2}' | cut -d/ -f1
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,830 - connection-manager - DEBUG - Collected stats for enP8p1s0 (Wired connection 1): RX=864140361, TX=31725554527
# ...
Mar 12 01:58:19 ark-jetson-devicelab-gps python3[612421]: 2026-03-12 01:58:19,910 - connection-manager - DEBUG - udpate_interface_stats Wants stats lock

# Last log before "Network stats client disconnected: c3yLfDCSydj3Us9wAAAD, reason: ping timeout"
```

And after this change my stats thread can acquire it and returns successfully

```bash
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,272 - connection-manager - INFO - Stats thread started
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,273 - connection-manager - DEBUG - NetworkReport Wants stats lock
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,273 - connection-manager - DEBUG - NetworkReport Got stats lock
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,273 - connection-manager - DEBUG - No active network interfaces found
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,273 - connection-manager - WARNING - No network interfaces found to report stats
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,334 - connection-manager - DEBUG - Running command: nmcli -g GENERAL.IP-IFACE connection show "Wired connection 1"
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,392 - connection-manager - DEBUG - Connection 'Wired connection 1' using IP interface: enP8p1s0
# ...
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,554 - connection-manager - DEBUG - Found 4 active NetworkManager connections
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,554 - connection-manager - DEBUG - Running command: ip -s link show enP8p1s0
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,564 - connection-manager - DEBUG - Running command: ip addr show enP8p1s0 | grep -w inet | head -1 | awk '{print $2}' | cut -d/ -f1
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,573 - connection-manager - DEBUG - Collected stats for enP8p1s0 (Wired connection 1): RX=893625116, TX=32957539986
# ...
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,641 - connection-manager - DEBUG - udpate_interface_stats Wants stats lock
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,641 - connection-manager - DEBUG - udpate_interface_stats Got stats lock
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,641 - connection-manager - DEBUG - udpate_interface_stats Freed stats lock
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,641 - connection-manager - DEBUG - NetworkReport Wants stats lock
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,641 - connection-manager - DEBUG - NetworkReport Got stats lock
# ... 
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,642 - connection-manager - DEBUG - Sorting summary...
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,642 - connection-manager - DEBUG - Done sorting summary...
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,642 - connection-manager - DEBUG - Generated summary for 4 active interfaces
Mar 12 03:05:49 ark-jetson-devicelab-gps python3[638474]: 2026-03-12 03:05:49,642 - connection-manager - DEBUG - NetworkReport Freed stats lock
# Ready to go again 
```