### PR TITLE
Fix ark-ui install: export NVM_DIR before running nvm installer

### DIFF
--- a/frontend/ark-ui/install.sh
+++ b/frontend/ark-ui/install.sh
@@ -11,19 +11,21 @@ cd "$SCRIPT_DIR"
 apt_get_install update
 apt_get_install install -y curl jq nginx
 
-# Install NVM (Node Version Manager)
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-
 # Determine the correct NVM directory based on XDG_CONFIG_HOME
+# Must be exported BEFORE running the installer so nvm installs into this path
+# rather than its default $HOME/.nvm.
 if [ -z "$XDG_CONFIG_HOME" ]; then
     export NVM_DIR="$HOME/.config/nvm"
 else
     export NVM_DIR="$XDG_CONFIG_HOME/nvm"
 fi
 
+# Install NVM (Node Version Manager)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+
 # Source the NVM scripts to use it in the same script
-source $NVM_DIR/nvm.sh
-source $NVM_DIR/bash_completion
+source "$NVM_DIR/nvm.sh"
+source "$NVM_DIR/bash_completion"
 
 # Install the desired Node.js version and set it as default
 nvm install 20


### PR DESCRIPTION
## Summary
- Fixes #63. The nvm v0.39.7 installer honors `$NVM_DIR` if set, otherwise defaults to `$HOME/.nvm`. `frontend/ark-ui/install.sh` was exporting `NVM_DIR` *after* the curl install, so nvm installed to `$HOME/.nvm` while the script sourced from `$HOME/.config/nvm/nvm.sh` — which didn't exist. All subsequent `nvm`/`npm` calls silently failed and the frontend never built.
- Move the `NVM_DIR` export above the installer so nvm installs into the path the rest of the script (and `services/ark-ui-backend/start_ark_ui_backend.sh`) expects.
- Also quoted the `source` paths for safety.

## Test plan
- [ ] Fresh Raspberry Pi flash: run `./install.sh`, confirm nvm lands in `$HOME/.config/nvm`, Node 20 installs, `ark-ui` builds, and `ark-ui-backend` starts.
- [ ] Jetson: same check.
- [ ] Re-run on a machine with a prior `$HOME/.nvm` (orphaned, harmless) to confirm the new install at `$HOME/.config/nvm` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)