### PR TITLE
Add missing -y flag to python3-RPi.GPIO installation

### DIFF
--- a/tools/install_software.sh
+++ b/tools/install_software.sh
@@ -277,7 +277,7 @@ if [ "$TARGET" = "jetson" ]; then
 
 ########## pi dependencies ##########
 elif [ "$TARGET" = "pi" ]; then
-	apt_get_install install python3-RPi.GPIO
+	apt_get_install install -y python3-RPi.GPIO
  	# Enable Wi-Fi radio
 	sudo nmcli radio wifi on
 	# https://www.raspberrypi.com/documentation/computers/os.html#python-on-raspberry-pi


### PR DESCRIPTION
I'm not that well versed with github but I had the install script get stuck running on the Pi6x while installing python3-RPi.GPIO. Looking at the script there isn't a -y flag to allows it to proceed.