### PR TITLE
i2s_gpio_example: match docs loopback example

### DIFF
--- a/platform/jetson/scripts/i2s_gpio_example.py
+++ b/platform/jetson/scripts/i2s_gpio_example.py
@@ -1,49 +1,34 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-# Script to demonstrate I2S GPIO functionality on ARK Jetson Carrier
-# Uses I2S0_DOUT as output and I2S0_DIN as input
-# Requires physical connection between pin 40 (DOUT) and pin 38 (DIN)
-# Note: Jetson.GPIO does not support controlling pull-up/down resistors
+# I2S GPIO loopback demo for ARK Jetson Carriers.
+#
+# Toggles HDR40 pin 40 (I2S0_DOUT) HIGH/LOW/HIGH/LOW and reads each
+# transition back on pin 38 (I2S0_DIN). Connect pin 40 to pin 38 with
+# a jumper wire before running.
+#
+# Requires the ARK I2S to GPIO overlay:
+#   sudo /opt/nvidia/jetson-io/config-by-hardware.py -n "ARK I2S to GPIO"
+#   sudo reboot
+#
+# Requires Jetson.GPIO >= 2.1.12 (the apt-shipped version doesn't
+# recognize the Orin Nano Super and fails with "Could not determine
+# Jetson model"). ARK-OS installs this for you; standalone users:
+#   sudo pip3 install 'Jetson.GPIO>=2.1.12'
 
-import Jetson.GPIO as GPIO
 import time
+import Jetson.GPIO as GPIO
 
-output_pin = 40  # I2S0_DOUT - Header pin 40
-input_pin = 38   # I2S0_DIN - Header pin 38
+GPIO.setmode(GPIO.BOARD)
+GPIO.setup(40, GPIO.OUT, initial=GPIO.LOW)  # I2S0_DOUT
+GPIO.setup(38, GPIO.IN)                     # I2S0_DIN
 
-def main():
-    GPIO.setmode(GPIO.BOARD)  # Jetson board numbering scheme
-    GPIO.setup(output_pin, GPIO.OUT, initial=GPIO.HIGH)
-    GPIO.setup(input_pin, GPIO.IN)
-
-    print("Starting I2S GPIO test. Press CTRL+C to exit")
-    print("Make sure pins 40 (DOUT) and 38 (DIN) are connected together")
-
-    curr_output_value = GPIO.HIGH
-
-    try:
-        while True:
-            GPIO.output(output_pin, curr_output_value)
-            print(f"Output pin {output_pin} set to: {curr_output_value}")
-
-            input_value = GPIO.input(input_pin)
-            print(f"Input pin {input_pin} read as: {input_value}")
-
-            if input_value == curr_output_value:
-                print("SUCCESS: Input matches output")
-            else:
-                print("FAILURE: Input doesn't match output")
-
-            curr_output_value = GPIO.LOW if curr_output_value == GPIO.HIGH else GPIO.HIGH
-
-            time.sleep(1)
-            print("--------------------------")
-
-    except KeyboardInterrupt:
-        print("\nExiting program")
-    finally:
-        GPIO.cleanup()
-        print("GPIO pins cleaned up")
-
-if __name__ == '__main__':
-    main()
+try:
+    for level in (GPIO.HIGH, GPIO.LOW, GPIO.HIGH, GPIO.LOW):
+        GPIO.output(40, level)
+        time.sleep(0.2)
+        got = GPIO.input(38)
+        label = "HIGH" if level else "LOW"
+        result = "PASS" if got == level else f"FAIL (read {got})"
+        print(f"DOUT=40 {label}  DIN=38 {got}  {result}")
+finally:
+    GPIO.cleanup()


### PR DESCRIPTION
## Summary

- Make `platform/jetson/scripts/i2s_gpio_example.py` match the canonical loopback example used in `ark_jetson_kernel/docs/gpio.md` and the gitbook GPIO Control pages (ARK-Electronics/gitbook#21).
- Single fixed-length HIGH/LOW/HIGH/LOW pass instead of an infinite loop; auto-exits with a clear PASS/FAIL line per transition. Closer to a smoke test, easier to skim output.
- Switch initial state from HIGH to LOW so the script doesn't briefly fight the carrier's 604Ω pullups on startup, and to match the BCT boot default.
- Header now mentions the Jetson.GPIO >=2.1.12 requirement for anyone running this standalone outside ARK-OS (ARK-OS itself already pins this in `tools/install_software.sh` since 1d98f32).

Three places — script, kernel-repo doc, gitbook — now hold byte-identical example bodies. Any future fix lands in one canonical form.

Related: ARK-Electronics/ark_jetson_kernel#60, ARK-Electronics/gitbook#21, NVIDIA/jetson-gpio#134.

## Test plan

- [ ] On an Orin Nano Super with the ARK I2S to GPIO overlay applied and a jumper from HDR40 pin 40 → pin 38, run `python3 platform/jetson/scripts/i2s_gpio_example.py`; confirm four PASS lines and a clean exit (exit 0, no traceback).
- [ ] Remove the jumper and re-run; confirm at least one HIGH transition reports FAIL with the actual read value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)