### PR TITLE
fix(packaging): bundle the MAVSDK SDK instead of depending on libmavsdk-dev

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -83,17 +83,21 @@ jobs:
         # formatter before cmake), so it is a build-time requirement too.
         # libgflags/libgoogle-glog/libboost are required by the Polaris SDK that
         # polaris-client-mavlink fetches and builds at configure time.
+        # patchelf pins the RUNPATH of the MAVSDK-linking binaries to the SDK
+        # bundled under /usr/lib/ark-os/mavsdk (build_binaries.sh; see issue #74).
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            cmake meson ninja-build pkg-config build-essential astyle file \
+            cmake meson ninja-build pkg-config build-essential astyle file patchelf \
             python3-pip python3-venv \
             libssl-dev libsqlite3-dev libunwind-dev \
             libgflags-dev libgoogle-glog-dev libboost-all-dev \
             libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstrtspserver-1.0-dev \
             lintian ${{ matrix.extra_deps }}
 
-      - name: Install MAVSDK (build-time only, to link libs/mavsdk-examples)
+      - name: Install MAVSDK (build-time link dep; its deb is also staged into the .deb)
+        # The deb stays in the workspace root: build_binaries.sh stages this
+        # exact file into the package, so what we link is what we ship.
         run: |
           . packaging/versions.env
           DEB="libmavsdk-dev_${MAVSDK_VERSION}_debian12_arm64.deb"
@@ -125,8 +129,9 @@ jobs:
           path: ark-os-${{ matrix.platform }}-${{ matrix.codename }}_*_arm64.deb
           if-no-files-found: error
 
-      # Attach the per-platform .deb to the release for this tag. MAVSDK is NOT
-      # rebundled — its canonical home is the upstream MAVSDK releases page.
+      # Attach the per-platform .deb to the release for this tag. The .deb
+      # bundles its own MAVSDK SDK, so there is no separate MAVSDK asset to
+      # publish or install.
       - name: Attach to GitHub Release
         # v* → official release; draft-* → public PRERELEASE (excluded from
         # "latest", clearly marked) so downstream builds fetch it without auth.

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ sudo nmcli dev wifi connect <ssid> password <password>
 
 # Installation
 
-ARK-OS is distributed as a Debian package on the [Releases page](https://github.com/ARK-Electronics/ARK-OS/releases). It depends on the MAVSDK C++ runtime, which has no apt repository — it is downloaded from the [upstream MAVSDK releases](https://github.com/mavlink/MAVSDK/releases). On Jetson, the web UI's system stats additionally need `jetson-stats` (jtop) installed system-wide. The install script below handles all of this; manual steps follow if you prefer.
+ARK-OS is distributed as a Debian package on the [Releases page](https://github.com/ARK-Electronics/ARK-OS/releases). The MAVSDK C++ SDK is bundled inside the package (see [MAVSDK](#mavsdk-bundled-usable-replaceable) below), so there is nothing to install separately and you are free to install your own MAVSDK system-wide without disturbing ARK-OS. On Jetson, the web UI's system stats additionally need `jetson-stats` (jtop) installed system-wide. The install script below handles all of this; manual steps follow if you prefer.
 
 ### Install / update with the script (recommended)
 
-`packaging/install_ark_os.sh` installs MAVSDK, `jetson-stats` (Jetson only), and ARK-OS in the correct order, and is also the supported way to update a live device. Run it from a checkout of this repo on the device:
+`packaging/install_ark_os.sh` installs `jetson-stats` (Jetson only) and ARK-OS in the correct order, and is also the supported way to update a live device. Run it from a checkout of this repo on the device:
 
 ```
 git clone https://github.com/ARK-Electronics/ARK-OS.git
@@ -40,18 +40,16 @@ sudo ./packaging/install_ark_os.sh --ark-os-version=X.Y.Z
 sudo ./packaging/install_ark_os.sh ./ark-os-jetson-jammy_X.Y.Z_arm64.deb
 ```
 
-The script auto-detects Jetson vs Pi (override with `--platform`), skips MAVSDK/jtop when they are already at the pinned versions, and re-runs safely for updates. The versions it installs are pinned in `packaging/versions.env`. Run `sudo ./packaging/install_ark_os.sh --help` for all options.
+The script auto-detects Jetson vs Pi (override with `--platform`), skips jtop when it is already at the pinned version, and re-runs safely for updates. The versions it installs are pinned in `packaging/versions.env`. Run `sudo ./packaging/install_ark_os.sh --help` for all options.
 
 ### Manual install
 
-Install MAVSDK first (ARK-OS depends on it), then ARK-OS. Replace `<mavsdk-ver>`, `<ark-os-ver>`, and `<jetson-stats-ver>` with the versions pinned in `packaging/versions.env`. The ARK-OS package name includes your OS release codename — `jammy` for JetPack 6, `trixie` for Raspberry Pi OS (Debian 13) or `bookworm` (Debian 12) — so pick the asset matching your device's `/etc/os-release` `VERSION_CODENAME`.
+MAVSDK is bundled inside the ARK-OS package, so you only install ARK-OS itself. Replace `<ark-os-ver>` and `<jetson-stats-ver>` with the versions pinned in `packaging/versions.env`. The ARK-OS package name includes your OS release codename — `jammy` for JetPack 6, `trixie` for Raspberry Pi OS (Debian 13) or `bookworm` (Debian 12) — so pick the asset matching your device's `/etc/os-release` `VERSION_CODENAME`.
 
 #### Jetson
 ```
-wget https://github.com/mavlink/MAVSDK/releases/download/v<mavsdk-ver>/libmavsdk-dev_<mavsdk-ver>_debian12_arm64.deb
 wget https://github.com/ARK-Electronics/ARK-OS/releases/download/v<ark-os-ver>/ark-os-jetson-jammy_<ark-os-ver>_arm64.deb
 
-sudo apt install ./libmavsdk-dev_<mavsdk-ver>_debian12_arm64.deb
 sudo apt install ./ark-os-jetson-jammy_<ark-os-ver>_arm64.deb
 
 # Recommended: jtop, for Jetson system stats in the web UI
@@ -61,15 +59,30 @@ sudo apt install -y python3-pip && sudo pip3 install "jetson-stats==<jetson-stat
 #### Raspberry Pi
 Identical, replacing `ark-os-jetson-jammy` with `ark-os-pi-trixie` for Raspberry Pi OS Trixie (Debian 13) — use `ark-os-pi-bookworm` on Debian 12. No jetson-stats step:
 ```
-wget https://github.com/mavlink/MAVSDK/releases/download/v<mavsdk-ver>/libmavsdk-dev_<mavsdk-ver>_debian12_arm64.deb
 wget https://github.com/ARK-Electronics/ARK-OS/releases/download/v<ark-os-ver>/ark-os-pi-trixie_<ark-os-ver>_arm64.deb
 
-sudo apt install ./libmavsdk-dev_<mavsdk-ver>_debian12_arm64.deb
 sudo apt install ./ark-os-pi-trixie_<ark-os-ver>_arm64.deb
 ```
 
+### MAVSDK: bundled, usable, replaceable
+
+ARK-OS ships its own MAVSDK — runtime library, headers, and CMake config — under `/usr/lib/ark-os/mavsdk`, and its binaries load that copy via RUNPATH. The bundled copy is deliberately kept **off** the system linker path, so it is invisible to every other program on the device: you can `apt install`/`apt remove` a system `libmavsdk-dev`, or `make install` your own build to `/usr/local`, and neither ARK-OS nor your own MAVSDK programs are affected — the two copies coexist.
+
+You can also build your own programs against the bundled SDK instead of installing MAVSDK yourself:
+
+```cmake
+find_package(MAVSDK REQUIRED)
+target_link_libraries(your_app MAVSDK::mavsdk)
+```
+
+```
+cmake -DCMAKE_PREFIX_PATH=/usr/lib/ark-os/mavsdk -B build && cmake --build build
+```
+
+Binaries run straight from the build tree work as-is (CMake's build RPATH covers them). If you `install` your program, set `CMAKE_INSTALL_RPATH=/usr/lib/ark-os/mavsdk/lib` so it finds the library at runtime. `pkg-config mavsdk` works too, via `PKG_CONFIG_PATH=/usr/lib/ark-os/mavsdk/lib/pkgconfig`. One caveat: the bundled MAVSDK tracks ARK-OS releases, so an ARK-OS upgrade may bump it under your program — if you need to pin your own MAVSDK version, install your own copy instead.
+
 ### Updating
-Re-run `install_ark_os.sh` (it upgrades ARK-OS in place and leaves MAVSDK/jtop alone when already current), or manually `sudo apt install ./ark-os-<platform>-<codename>_<ver>_arm64.deb`. **Upgrading resets the per-service configuration under `/etc/ark-os/` to packaged defaults** — reconfigure via the web UI afterward.
+Re-run `install_ark_os.sh` (it upgrades ARK-OS in place and leaves jtop alone when already current), or manually `sudo apt install ./ark-os-<platform>-<codename>_<ver>_arm64.deb`. **Upgrading resets the per-service configuration under `/etc/ark-os/` to packaged defaults** — reconfigure via the web UI afterward.
 
 ### Migrating from a source install
 Installing the package on a device that was set up with the old `install.sh` flow migrates it automatically: the legacy user services and binaries are removed and your previous configs are backed up to `~/.config/ark-os-legacy-backup/`. **Reboot after installing** so no stale user-session services keep holding the autopilot UART / MAVLink ports.

--- a/packaging/DEBIAN/control
+++ b/packaging/DEBIAN/control
@@ -3,7 +3,7 @@ Version: @VERSION@
 Section: embedded
 Priority: optional
 Architecture: arm64
-Depends: nginx, @PYTHON@, @PYTHON@-venv, avahi-daemon, libgstreamer1.0-0, libgstreamer-plugins-base1.0-0, libgstrtspserver-1.0-0, gstreamer1.0-plugins-ugly, gstreamer1.0-plugins-bad, gstreamer1.0-tools, gstreamer1.0-gl, gstreamer1.0-rtsp, libssl3t64 | libssl3, libsqlite3-0, libcap2-bin, curl, jq, systemd, network-manager, libmavsdk-dev (>= 3.0)@EXTRA_DEPENDS@
+Depends: nginx, @PYTHON@, @PYTHON@-venv, avahi-daemon, libgstreamer1.0-0, libgstreamer-plugins-base1.0-0, libgstrtspserver-1.0-0, gstreamer1.0-plugins-ugly, gstreamer1.0-plugins-bad, gstreamer1.0-tools, gstreamer1.0-gl, gstreamer1.0-rtsp, libssl3t64 | libssl3, libsqlite3-0, libcap2-bin, curl, jq, systemd, network-manager@EXTRA_DEPENDS@
 Provides: ark-os-@PLATFORM@
 Conflicts: ark-os-@PLATFORM@
 Replaces: ark-os-@PLATFORM@

--- a/packaging/assemble_tree.sh
+++ b/packaging/assemble_tree.sh
@@ -10,9 +10,10 @@ PKG="$BUILD_DIR"
 P="$PLATFORM"
 ARK="$PKG_PREFIX"   # /usr/lib/ark-os
 
-# Platform-specific control Depends. EXTRA_DEPENDS is a suffix inserted after
-# libmavsdk-dev. PYTHON_PKG (the system python the bundled venv binds to) and
-# CODENAME come from build.sh, which resolves them from the build host's release.
+# Platform-specific control Depends. EXTRA_DEPENDS is a suffix appended to the end
+# of the base Depends list (after network-manager). PYTHON_PKG (the system python
+# the bundled venv binds to) and CODENAME come from build.sh, which resolves them
+# from the build host's release.
 # NOTE: the base Depends in DEBIAN/control target the supported releases' lib names.
 # Trixie's time64 transition renamed libssl3 -> libssl3t64, handled in control by the
 # alternative "libssl3t64 | libssl3"; use the same idiom if a future release renames more.
@@ -151,9 +152,10 @@ fi
 install -m 0644 packaging/system-config/10-ark-os.conf \
     "$PKG/etc/systemd/journald.conf.d/10-ark-os.conf"
 
-# --- ld.so.conf for the private C++ libs (polaris SDK + Micro-XRCE-DDS agent and
-# its FastDDS chain) that build_binaries.sh bundles under $ARK/lib. ldconfig in the
-# postinst builds the cache so the loader finds them on-device. ---
+# --- ld.so.conf for the private C++ libs bundled under $ARK/lib (postinst runs
+# ldconfig). $ARK/mavsdk/lib is deliberately absent: conf.d dirs beat /usr/lib
+# and /usr/local/lib in cache order, so listing it would shadow a user-installed
+# MAVSDK; ark-os binaries use RUNPATH instead (build_binaries.sh). ---
 mkdir -p "$PKG/etc/ld.so.conf.d"
 printf '%s\n' "$ARK/lib" > "$PKG/etc/ld.so.conf.d/ark-os.conf"
 chmod 0644 "$PKG/etc/ld.so.conf.d/ark-os.conf"

--- a/packaging/build_binaries.sh
+++ b/packaging/build_binaries.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # Compile the C++ submodules natively and stage their binaries into the package
 # tree at $PKG_PREFIX/bin. Invoked by build.sh (PLATFORM, BUILD_DIR, REPO_ROOT,
-# PKG_PREFIX in the environment). Requires MAVSDK already installed on the
-# system (the CI workflow installs libmavsdk-dev before this runs) so that
-# libs/mavsdk-examples can link.
+# PKG_PREFIX, MAVSDK_VERSION, CODENAME in the environment). Linking needs a
+# system-installed MAVSDK; the .deb ships its own copy (MAVSDK step below).
 set -euo pipefail
 
 cd "$REPO_ROOT"
@@ -12,20 +11,15 @@ LIB_DIR="$BUILD_DIR$PKG_PREFIX/lib"
 mkdir -p "$BIN_DIR" "$LIB_DIR"
 NPROC="$(nproc)"
 
-# Bundle a freshly-built binary's private (build-tree) shared-library deps into
-# LIB_DIR. The polaris SDK (libpolaris_cpp_client) and the Micro-XRCE-DDS agent +
-# its FastDDS/FastCDR chain are FetchContent/temp_install libs that exist only in
-# the submodule build trees, so `install`-ing just the executable leaves them
-# missing on-device (loader error 127). ldd is run while the binary's build-tree
-# RUNPATH still resolves; only libs resolving inside $REPO_ROOT are copied — system
-# libs and apt Depends (libmavsdk, gstreamer, bluez, openssl, sqlite) resolve
-# elsewhere and stay external. A shipped /etc/ld.so.conf.d/ark-os.conf + ldconfig
-# (postinst) make these findable, so the stale build-tree RUNPATH is harmless (the
-# loader falls through to the cache). Fail loud if anything is unresolved at build.
-# Install a resolved shared library into LIB_DIR under its soname, failing loud on
-# a name collision: two services may each bundle a private lib with the same
-# basename, and silently overwriting one with a different build would break the
-# loser at load time. An identical duplicate (same bytes) is accepted as a no-op.
+# Bundle a binary's build-tree-only shared libs (polaris SDK, Micro-XRCE-DDS +
+# FastDDS chain — FetchContent libs that exist nowhere on-device) into LIB_DIR,
+# found via ldd while the build-tree RUNPATH still resolves. Only paths inside
+# $REPO_ROOT are copied: system libs and apt Depends stay external, which also
+# skips the system-installed MAVSDK (staged separately below). On-device they
+# resolve via /etc/ld.so.conf.d/ark-os.conf + postinst ldconfig, so the stale
+# build-tree RUNPATH is harmless. A same-name lib with different bytes aborts:
+# silently overwriting one service's private lib with another's would break the
+# loser at load time.
 install_bundled_lib() {
     local src dest
     src="$(readlink -f "$1")"
@@ -87,12 +81,8 @@ echo "==> polaris-client-mavlink (make -> cmake)"
 ( cd services/polaris/polaris-client-mavlink && make )
 install -m 0755 services/polaris/polaris-client-mavlink/build/polaris-client-mavlink "$BIN_DIR/"
 bundle_build_tree_libs services/polaris/polaris-client-mavlink/build/polaris-client-mavlink
-# The Polaris SDK also links libglog (and, where glog links it, libgflags), which
-# are installed on the build runner (see the CI build-deps step) but ship on
-# neither the Jetson nor the Pi rootfs and are not apt Depends. Their package names
-# differ across releases (libgoogle-glog0v5 / 0v6t64 / Debian's own), so a single
-# shared Depends would be wrong on one target — bundle the libs instead. ldd
-# resolves them (recursively, so glog's gflags dep is included) to system paths.
+# glog/gflags ship on neither rootfs, and their package names differ across
+# releases (libgoogle-glog0v5 / 0v6t64 / …) so no single Depends fits — bundle.
 polaris_extra_libs="$(ldd services/polaris/polaris-client-mavlink/build/polaris-client-mavlink \
     | awk '/=> \// {print $3}' | grep -E '/lib(glog|gflags)\.so' || true)"
 [ -n "$polaris_extra_libs" ] \
@@ -111,23 +101,124 @@ echo "==> mavsdk-examples (cmake)"
 ( cd libs/mavsdk-examples
   cmake -B build -DCMAKE_BUILD_TYPE=Release
   cmake --build build -j"$NPROC" )
-# Each example builds to build/<subdir>/<output_name>. Collect every ELF
-# executable except CMake's own compiler-probe artifacts under CMakeFiles/.
+# Collect every built ELF executable, skipping CMake's compiler probes.
 find libs/mavsdk-examples/build -type f -perm -u+x -not -path '*/CMakeFiles/*' | while read -r f; do
     if file -b "$f" | grep -q 'ELF .* executable'; then
         install -m 0755 "$f" "$BIN_DIR/"
     fi
 done
 
-# Fail loud if the private libs the FetchContent/cmake services need did not get
-# bundled (e.g. an ldd / path-filter regression) — shipping the binaries without
-# them reproduces the on-device "cannot open shared object" crash.
+# --- MAVSDK: stage the pinned upstream deb's full SDK under $PKG_PREFIX/mavsdk ---
+# MAVSDK is on no apt repo, so it cannot be a Depends (issue #74). Bundle the
+# deb the build linked against (link == ship), headers and CMake config included
+# so users can build against it (README). The directory is deliberately absent
+# from ld.so.conf.d: a globally visible libmavsdk.so.3 would shadow a
+# user-installed MAVSDK. ark-os binaries reach it via RUNPATH instead (below).
+echo "==> MAVSDK SDK ($MAVSDK_VERSION)"
+MAVSDK_DEB_NAME="libmavsdk-dev_${MAVSDK_VERSION}_debian12_arm64.deb"
+# Prefer the deb CI's "Install MAVSDK" step left in the workspace root, then a
+# cached download under build/.
+MAVSDK_DEB=""
+for cand in "$REPO_ROOT/$MAVSDK_DEB_NAME" "$REPO_ROOT/build/$MAVSDK_DEB_NAME"; do
+    if [ -f "$cand" ]; then MAVSDK_DEB="$cand"; break; fi
+done
+if [ -z "$MAVSDK_DEB" ]; then
+    MAVSDK_DEB="$REPO_ROOT/build/$MAVSDK_DEB_NAME"
+    echo "    downloading $MAVSDK_DEB_NAME"
+    curl -fsSL -o "$MAVSDK_DEB.partial" \
+        "https://github.com/mavlink/MAVSDK/releases/download/v${MAVSDK_VERSION}/${MAVSDK_DEB_NAME}"
+    mv "$MAVSDK_DEB.partial" "$MAVSDK_DEB"
+fi
+
+MAVSDK_STAGE="$BUILD_DIR$PKG_PREFIX/mavsdk"
+echo "    staging $(basename "$MAVSDK_DEB") -> $MAVSDK_STAGE"
+mavsdk_extract="$(mktemp -d)"
+dpkg-deb -x "$MAVSDK_DEB" "$mavsdk_extract"
+mkdir -p "$MAVSDK_STAGE"
+# usr/{include,lib} is the whole SDK (usr/share is just a changelog); the
+# CMake config is relocatable.
+cp -a "$mavsdk_extract/usr/include" "$mavsdk_extract/usr/lib" "$MAVSDK_STAGE/"
+rm -rf "$mavsdk_extract"
+
+# Upstream ships only the versioned file, relying on ldconfig for the soname
+# symlink — which never runs for this off-loader-path dir, so ship the chain:
+# RUNPATH lookup is by soname filename, and the dev symlink lets -lmavsdk link.
+mavsdk_so=""
+for f in "$MAVSDK_STAGE"/lib/libmavsdk.so.*; do
+    [ -e "$f" ] || continue
+    [ -z "$mavsdk_so" ] || { echo "ERROR: multiple libmavsdk.so.* in $MAVSDK_DEB_NAME" >&2; exit 1; }
+    mavsdk_so="$f"
+done
+[ -n "$mavsdk_so" ] || { echo "ERROR: no libmavsdk.so.* found in $MAVSDK_DEB_NAME" >&2; exit 1; }
+mavsdk_soname="$(readelf -d "$mavsdk_so" | sed -n 's/.*(SONAME).*\[\(.*\)\]$/\1/p')"
+[ -n "$mavsdk_soname" ] || { echo "ERROR: could not read SONAME from $mavsdk_so" >&2; exit 1; }
+if [ "$(basename "$mavsdk_so")" != "$mavsdk_soname" ]; then
+    ln -snf "$(basename "$mavsdk_so")" "$MAVSDK_STAGE/lib/$mavsdk_soname"
+fi
+ln -snf "$mavsdk_soname" "$MAVSDK_STAGE/lib/libmavsdk.so"
+
+# mavsdk.pc ships with upstream's CI build prefix baked in; fix it. Drop
+# Requires.private: those deps are static inside libmavsdk, and their missing
+# .pc files would fail every on-device pkg-config query.
+sed -i \
+    -e "s|^prefix=.*|prefix=$PKG_PREFIX/mavsdk|" \
+    -e 's|^exec_prefix=.*|exec_prefix=${prefix}|' \
+    -e 's|^libdir=.*|libdir=${prefix}/lib|' \
+    -e 's|^includedir=.*|includedir=${prefix}/include|' \
+    -e '/^Requires\.private:/d' \
+    "$MAVSDK_STAGE/lib/pkgconfig/mavsdk.pc"
+
+# The .so is upstream's debian12 build: verify the glibc/libstdc++ symbol
+# versions it needs exist on this host (== target codename, per build.sh), else
+# it fails on-device with "version not found". Likely trip: a MAVSDK_VERSION bump.
+max_symver() {  # highest <FAMILY>_x[.y...] referenced/provided by an ELF
+    readelf -V "$1" 2>/dev/null | grep -oE "${2}_[0-9]+(\.[0-9]+)+" | sort -uV | tail -1 || true
+}
+for fam_provider in GLIBC:libc.so.6 GLIBCXX:libstdc++.so.6 CXXABI:libstdc++.so.6; do
+    fam="${fam_provider%%:*}"
+    req="$(max_symver "$mavsdk_so" "$fam")"
+    [ -n "$req" ] || continue
+    # no early exit in awk: SIGPIPE on ldconfig would trip pipefail
+    provider="$(ldconfig -p | awk -v so="${fam_provider#*:}" '$1 == so && !found {print $NF; found=1}')"
+    [ -n "$provider" ] || { echo "ERROR: ${fam_provider#*:} not found on the build host" >&2; exit 1; }
+    prov="$(max_symver "$provider" "$fam")"
+    if [ -z "$prov" ] || [ "$(printf '%s\n%s\n' "$req" "$prov" | sort -V | tail -1)" != "$prov" ]; then
+        echo "ERROR: bundled MAVSDK needs $fam $req; the $CODENAME build host (= target rootfs) provides ${prov:-none}." >&2
+        echo "       It would fail on-device with a 'version not found' load error. Pin a" >&2
+        echo "       MAVSDK_VERSION / deb variant compatible with $CODENAME in versions.env." >&2
+        exit 1
+    fi
+    echo "    ABI: $fam $req required <= $prov provided (ok)"
+done
+
+# RUNPATH beats the loader cache, pinning every libmavsdk-linking binary to the
+# bundled copy even if a system libmavsdk appears later; ../lib stays on it for
+# the other bundled private libs.
+command -v patchelf >/dev/null \
+    || { echo "ERROR: patchelf not found — required to pin the bundled-MAVSDK RUNPATH" >&2; exit 1; }
+mavsdk_linkers=0
+while read -r bin; do
+    readelf -d "$bin" 2>/dev/null | grep -q 'NEEDED.*\[libmavsdk\.so' || continue
+    patchelf --set-rpath '$ORIGIN/../lib:$ORIGIN/../mavsdk/lib' "$bin"
+    mavsdk_linkers=$((mavsdk_linkers + 1))
+done < <(find "$BIN_DIR" -maxdepth 1 -type f -perm -u+x)
+[ "$mavsdk_linkers" -gt 0 ] \
+    || { echo "ERROR: no staged binary links libmavsdk — MAVSDK bundling found nothing to pin" >&2; exit 1; }
+
+# A missed bundle (ldd/path-filter regression) crashes on-device at load — fail here instead.
 for must in 'libpolaris_cpp_client.so*' 'libmicroxrcedds_agent.so*' 'libglog.so*'; do
     compgen -G "$LIB_DIR/$must" >/dev/null \
         || { echo "ERROR: no library matching '$must' was bundled into $LIB_DIR" >&2; exit 1; }
+done
+for must in "lib/$mavsdk_soname" lib/libmavsdk.so lib/cmake/MAVSDK/MAVSDKConfig.cmake \
+            lib/pkgconfig/mavsdk.pc include/mavsdk/mavsdk.h; do
+    [ -e "$MAVSDK_STAGE/$must" ] \
+        || { echo "ERROR: staged MAVSDK SDK is missing $must" >&2; exit 1; }
 done
 
 echo "==> binaries staged in $BIN_DIR:"
 ls -1 "$BIN_DIR"
 echo "==> libraries bundled in $LIB_DIR:"
 ls -1 "$LIB_DIR"
+echo "==> MAVSDK SDK staged in $MAVSDK_STAGE:"
+ls -1 "$MAVSDK_STAGE/lib"

--- a/packaging/install_ark_os.sh
+++ b/packaging/install_ark_os.sh
@@ -5,18 +5,19 @@
 # bakes the same packages into a Jetson image at build time (--provision). It
 # performs the installs a plain `apt install ./ark-os-*.deb` does NOT do itself:
 #
-#   1. libmavsdk-dev  — a hard Depends of ark-os that lives on no apt repo, so
-#                       apt cannot auto-resolve it; it must be installed first.
-#   2. jetson-stats   — the jtop client system-manager uses for the web UI's
+#   1. jetson-stats   — the jtop client system-manager uses for the web UI's
 #      (Jetson only)    Jetson stats. Not an apt Depends and not in the bundled
 #                       venv (the venv imports it via system-site-packages).
-#   3. ark-os-<plat>  — the package itself; its postinst does the rest. apt pulls
+#   2. ark-os-<plat>  — the package itself; its postinst does the rest. apt pulls
 #                       the remaining Depends (nginx, gstreamer, bluez, …) from
 #                       the device's normal Ubuntu repos.
 #
-# Re-running is safe: MAVSDK and jetson-stats are skipped when already at the
-# pinned version, and re-installing the ark-os deb upgrades it in place — so this
-# is also the supported way to update a live device.
+# MAVSDK is not installed here: the ark-os .deb bundles its own SDK under
+# /usr/lib/ark-os/mavsdk (issue #74), independent of any system MAVSDK.
+#
+# Re-running is safe: jetson-stats is skipped when already at the pinned version,
+# and re-installing the ark-os deb upgrades it in place — so this is also the
+# supported way to update a live device.
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
@@ -29,7 +30,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=packaging/versions.env
 [ -f "$SCRIPT_DIR/versions.env" ] && source "$SCRIPT_DIR/versions.env"
 
-MAVSDK_REPO="https://github.com/mavlink/MAVSDK"
 ARK_OS_REPO="https://github.com/ARK-Electronics/ARK-OS"
 
 die()  { echo "ERROR: $*" >&2; exit 1; }
@@ -40,8 +40,9 @@ usage() {
     cat >&2 <<'EOF'
 Usage: sudo ./install_ark_os.sh [options] [ARK_OS_DEB]
 
-Installs MAVSDK, jetson-stats (Jetson only), and ARK-OS on a live device in the
-correct order. Also the supported way to update a live device.
+Installs jetson-stats (Jetson only) and ARK-OS on a live device in the correct
+order. Also the supported way to update a live device. (MAVSDK is bundled inside
+the ark-os package and is no longer installed separately.)
 
 Positional:
   ARK_OS_DEB                Path to a local ark-os-<platform>-<codename>_<ver>_arm64.deb. If
@@ -55,14 +56,12 @@ Options:
                             jammy, …). Only needed to name a download when /etc/os-release
                             can't be read.
   --ark-os-version=X.Y.Z    Download this ark-os release when no local deb is given.
-  --mavsdk-deb=PATH         Install MAVSDK from a local deb instead of downloading.
-  --mavsdk-version=X.Y.Z    Override the MAVSDK version (default from versions.env).
   --jetson-stats-version=X  Override the jetson-stats version (default from versions.env).
   --skip-jtop               Do not install jetson-stats (Jetson only).
   -h, --help                Show this help.
 
-Versions default to packaging/versions.env. MAVSDK has no apt repo; jetson-stats
-is installed system-wide via pip so the web UI can report Jetson stats.
+Versions default to packaging/versions.env. jetson-stats is installed system-wide
+via pip so the web UI can report Jetson stats.
 EOF
 }
 
@@ -71,9 +70,7 @@ PLATFORM=""
 CODENAME=""
 DEB_ARG=""
 ARK_OS_VERSION=""
-MAVSDK_DEB=""
 SKIP_JTOP=0
-OPT_MAVSDK_VERSION=""
 OPT_JETSON_STATS_VERSION=""
 
 for arg in "$@"; do
@@ -81,8 +78,6 @@ for arg in "$@"; do
         --platform=*)            PLATFORM="${arg#*=}" ;;
         --codename=*)             CODENAME="${arg#*=}" ;;
         --ark-os-version=*)       ARK_OS_VERSION="${arg#*=}" ;;
-        --mavsdk-deb=*)           MAVSDK_DEB="${arg#*=}" ;;
-        --mavsdk-version=*)       OPT_MAVSDK_VERSION="${arg#*=}" ;;
         --jetson-stats-version=*) OPT_JETSON_STATS_VERSION="${arg#*=}" ;;
         --skip-jtop)              SKIP_JTOP=1 ;;
         -h|--help)                usage; exit 0 ;;
@@ -94,7 +89,6 @@ for arg in "$@"; do
 done
 
 # Flags/env override versions.env.
-MAVSDK_VERSION="${OPT_MAVSDK_VERSION:-${MAVSDK_VERSION:-}}"
 JETSON_STATS_VERSION="${OPT_JETSON_STATS_VERSION:-${JETSON_STATS_VERSION:-}}"
 
 # --- Preconditions ---
@@ -177,8 +171,6 @@ info "Platform: $PLATFORM"
 getent passwd "$PLATFORM" >/dev/null 2>&1 || \
     die "ARK-OS services run as the user '$PLATFORM', which does not exist on this device. Re-image with the username '$PLATFORM', or create it first: sudo useradd -m -s /bin/bash $PLATFORM && sudo passwd $PLATFORM && sudo usermod -aG sudo $PLATFORM"
 
-[ -n "$MAVSDK_VERSION" ] || die "MAVSDK version unknown (no versions.env and no --mavsdk-version)."
-
 # --- Scratch space for downloads ---
 DL_DIR="$(mktemp -d)"
 trap 'rm -rf "$DL_DIR"' EXIT
@@ -212,26 +204,7 @@ info "Refreshing apt package indices"
 apt-get update || warn "apt-get update failed; continuing with existing indices."
 
 # ===========================================================================
-# 1. MAVSDK — hard Depends of ark-os, not in any apt repo. Install first.
-# ===========================================================================
-installed_mavsdk="$(dpkg-query -W -f='${Version}' libmavsdk-dev 2>/dev/null || true)"
-if [ "$installed_mavsdk" = "$MAVSDK_VERSION" ]; then
-    info "libmavsdk-dev $MAVSDK_VERSION already installed — skipping."
-else
-    if [ -n "$MAVSDK_DEB" ]; then
-        [ -f "$MAVSDK_DEB" ] || die "MAVSDK deb not found: $MAVSDK_DEB"
-    else
-        # Upstream ships no ubuntu22.04_arm64 asset; debian12_arm64 is glibc-
-        # compatible with the JetPack 6 / Jammy rootfs in practice.
-        MAVSDK_DEB="$DL_DIR/libmavsdk-dev_${MAVSDK_VERSION}_debian12_arm64.deb"
-        fetch "$MAVSDK_REPO/releases/download/v${MAVSDK_VERSION}/$(basename "$MAVSDK_DEB")" "$MAVSDK_DEB"
-    fi
-    info "Installing MAVSDK $MAVSDK_VERSION"
-    apt_install_deb "$MAVSDK_DEB"
-fi
-
-# ===========================================================================
-# 2. jetson-stats (jtop) — Jetson only. Optional: system-manager degrades
+# 1. jetson-stats (jtop) — Jetson only. Optional: system-manager degrades
 #    gracefully without it, so a failure here warns but does not abort.
 #    Installed before ark-os so jtop.service is up when system-manager starts.
 # ===========================================================================
@@ -252,7 +225,7 @@ if [ "$PLATFORM" = "jetson" ] && [ "$SKIP_JTOP" -eq 0 ]; then
 fi
 
 # ===========================================================================
-# 3. ark-os — its postinst configures users/groups/services and (on a running
+# 2. ark-os — its postinst configures users/groups/services and (on a running
 #    system) starts everything.
 # ===========================================================================
 info "Installing $(basename "$ARK_OS_DEB")"

--- a/packaging/versions.env
+++ b/packaging/versions.env
@@ -4,19 +4,21 @@
 # SINGLE SOURCE OF TRUTH — sourced as bash (plain KEY="value" lines). Consumers:
 #   - packaging/build.sh              builds the .deb (links mavsdk-examples, bundles Node)
 #   - packaging/install_ark_os.sh     installs/updates a live device
-#   - .github/workflows/build-deb.yml CI: installs MAVSDK to link mavsdk-examples
+#   - .github/workflows/build-deb.yml CI: installs MAVSDK to link the C++ services
 #
 # ark_jetson_kernel/provision.sh (a different repo, with no ARK-OS checkout at
-# build time) keeps its own copies of MAVSDK_VERSION / JETSON_STATS_VERSION —
-# keep them in sync with the values here when bumping.
+# build time) keeps its own copy of JETSON_STATS_VERSION — keep it in sync with
+# the value here when bumping. (MAVSDK is bundled inside the ark-os .deb, so the
+# image build no longer pins or installs it.)
 #
 # Bump on upgrade; each value is matched by exact filename against the upstream
 # release asset.
 
-# MAVSDK C++ runtime (libmavsdk-dev). Hard runtime dependency of ark-os, and
-# needed at build time to link libs/mavsdk-examples. Upstream publishes no
-# ubuntu22.04_arm64 asset; the debian12_arm64 build is glibc-compatible with the
-# JetPack 6 / Jammy rootfs in practice.
+# MAVSDK C++ SDK (libmavsdk-dev). Links the C++ services at build time; the same
+# deb is staged into the ark-os .deb under /usr/lib/ark-os/mavsdk, so it is not
+# a Depends and not installed by install_ark_os.sh (issue #74). Upstream has no
+# ubuntu22.04_arm64 asset; build_binaries.sh verifies the debian12_arm64 build's
+# symbol versions against each target release.
 MAVSDK_VERSION="3.17.1"
 
 # jetson-stats (jtop). Installed system-wide on Jetson so system-manager's jtop


### PR DESCRIPTION
## Summary
fixes #74

The ark-os deb now ships the complete MAVSDK SDK — runtime lib, headers, CMake config — under `/usr/lib/ark-os/mavsdk`, deliberately off the global loader path, and drops the `Depends: libmavsdk-dev`. ARK-OS, a system-wide MAVSDK, and programs built against either now coexist without interfering, and nothing has to be installed before the ark-os deb.

## Problem
MAVSDK lives on no apt repo, so the hard `Depends: libmavsdk-dev (>= 3.0)` was unresolvable by apt: every install path (`install_ark_os.sh`, the Jetson image provisioning) had to hand-install the deb first, and `apt remove libmavsdk-dev` cascaded into removing all of ark-os when an operator only meant to swap in their own MAVSDK build.

Bundling only the runtime `.so` into `/usr/lib/ark-os/lib` (this PR's first iteration) was not enough: that directory is on the global loader path via `/etc/ld.so.conf.d/ark-os.conf`, and conf.d directories beat `/usr/lib` and `/usr/local/lib` in loader-cache order — the bundled `libmavsdk.so.3` would silently shadow a user-installed MAVSDK for the *user's own* programs, the exact workflow #74 asks for. It also shipped nothing to build against.

## Solution
`build_binaries.sh` stages the entire payload of the pinned upstream deb — the same file the build links against, so link == ship — into `/usr/lib/ark-os/mavsdk`, adds the soname + dev symlinks upstream's deb lacks, and rewrites `mavsdk.pc`'s broken prefix. The directory is excluded from `ld.so.conf.d` on purpose; the MAVSDK-linking binaries get RUNPATH `$ORIGIN/../lib:$ORIGIN/../mavsdk/lib` via patchelf. Isolation is two-way: a system MAVSDK install/remove never affects ark-os, and the bundled copy is invisible to every other program's loader lookup.

Developers can link against the shipped SDK (`cmake -DCMAKE_PREFIX_PATH=/usr/lib/ark-os/mavsdk`, or `PKG_CONFIG_PATH=/usr/lib/ark-os/mavsdk/lib/pkgconfig`) or install their own — see the new README section. The glibc/libstdc++ symbol-version check from ark_jetson_kernel's `check_mavsdk_abi.sh` moves into the bundling step, run against the build host (== target codename per the CI matrix), keeping the debian12-build-on-jammy tripwire.

A companion ark_jetson_kernel PR drops the separate MAVSDK install at image-provision time; it must merge only after this ships in a release, since older ark-os debs still carry the Depends.
