### PR TITLE
fix(services): autostart toggle + bind managers/gateway to localhost

### DIFF
--- a/frontend/src/pages/ServicesPage.vue
+++ b/frontend/src/pages/ServicesPage.vue
@@ -115,20 +115,18 @@ export default {
       const newStatus = service.enabled === 'enabled' ? 'disable' : 'enable';
       axios.post(`/api/service/${newStatus}?serviceName=${service.name}`)
         .then(response => {
-          if (response.status === 200) {
-            console.log(`Service ${service.name} ${newStatus}d successfully`);
-            service.enabled = newStatus === 'enable' ? 'enabled' : 'disabled';
-          } else {
-            console.error(`Failed to ${newStatus} service ${service.name}`);
-            alert(`Failed to ${newStatus} service ${service.name}`);
+          // Action results are always HTTP 200; the real outcome is in the body.
+          if (response.data.status !== 'success') {
+            console.error(`Failed to ${newStatus} service ${service.name}: ${response.data.message}`);
+            alert(`Failed to ${newStatus} ${service.name}: ${response.data.message}`);
           }
         })
         .catch(error => {
           console.error(`Error ${newStatus} service:`, error);
-          alert(`Error ${newStatus} service`);
-          // Revert the toggle if there was an error
-          service.enabled = service.enabled === 'enabled' ? 'disabled' : 'enabled';
-        });
+          alert(`Error ${newStatus} ${service.name}`);
+        })
+        // Re-sync the toggle from the server instead of guessing the new state.
+        .finally(() => this.fetchServiceStatuses());
     },
     startService(serviceName) {
       axios.post(`/api/service/start?serviceName=${serviceName}`)

--- a/packaging/system-config/03-ark-service-manager.rules
+++ b/packaging/system-config/03-ark-service-manager.rules
@@ -30,12 +30,21 @@ polkit.addRule(function(action, subject) {
         return polkit.Result.YES;
     }
 
-    if (action.id == "org.freedesktop.systemd1.manage-units" ||
-        action.id == "org.freedesktop.systemd1.manage-unit-files") {
+    // start/stop/restart (manage-units) carry the target unit as a polkit detail,
+    // so scope these to ARK-OS units.
+    if (action.id == "org.freedesktop.systemd1.manage-units") {
         var unit = action.lookup("unit");
         if (unit && ARK_OS_UNITS.indexOf(unit) !== -1) {
             return polkit.Result.YES;
         }
+    }
+
+    // enable/disable (manage-unit-files) act on a list of files, so systemd passes
+    // no "unit" detail — action.lookup("unit") is null and per-unit scoping is
+    // impossible. Grant it to the service user, matching the blanket grant the
+    // .pkla already gives on Jetson; without it the autostart toggle is denied.
+    if (action.id == "org.freedesktop.systemd1.manage-unit-files") {
+        return polkit.Result.YES;
     }
 
     // Hostname control for connection-manager / system-manager.


### PR DESCRIPTION
## Summary

Two service-layer fixes found while validating the Pi before a release: the autostart toggle never worked, and internal HTTP surfaces were bound to all interfaces.

## Problem

Autostart: `systemctl enable`/`disable` are gated by the polkit action `manage-unit-files`, which — unlike `manage-units` (start/stop/restart) — operates on a list of files and carries no `unit` detail. The JS polkit rule required `action.lookup("unit")` to match an allowlist, so enable/disable always fell through to denial. On trixie (polkit 126) the JS `.rules` is the only authority (the shipped `.pkla` is inert), so the toggle is dead on the Pi. The failure was also invisible: the service-manager returns HTTP 200 with the real outcome in the body `status`, but the frontend only checked the HTTP status.

Binds: `autopilot-manager` defaulted `--host` to `0.0.0.0` and the gateway called `server.listen(PORT)` with no host, so both were reachable directly on every interface — including the device's Wi-Fi AP — bypassing nginx. The other two managers already bind localhost.

## Solution

Split the polkit rule: keep per-unit scoping for `manage-units`, grant `manage-unit-files` to the service user (the breadth the `.pkla` already grants on Jetson). Frontend `toggleService` now checks `response.data.status`, surfaces the backend message, and re-syncs from `/statuses`. Bind `autopilot-manager` and the gateway to `127.0.0.1` (the gateway honors `HOST=0.0.0.0` as an opt-in); the public surface stays nginx :80.
