### PR TITLE
fix(packaging): preserve user configs across deb upgrades

### DIFF
--- a/packaging/DEBIAN/postinst
+++ b/packaging/DEBIAN/postinst
@@ -170,10 +170,26 @@ mkdir -p /var/lib/ark-os/logs /var/lib/ark-os/flight-review/data
 chown -R "$ARK_USER:$ARK_USER" /var/lib/ark-os
 
 # ===========================================================================
+# Step 2b: Reconcile config templates into /etc/ark-os. Defaults ship under
+# config-defaults/ (not /etc/ark-os) so a dpkg upgrade never clobbers live
+# configs; this seeds them on first install and merges them on upgrade — new
+# fields added, removed scalar fields dropped, user values (and user-added
+# sections) kept. preinst snapshots the pre-upgrade configs to .config-backup,
+# which the helper prefers over the live file. Runs under the bundled venv for
+# the `toml` lib; a no-op-safe seed in the build chroot (empty /etc/ark-os).
+# ===========================================================================
+mkdir -p /etc/ark-os
+if [ -x /usr/lib/ark-os/venv/bin/python3 ] && [ -d /usr/lib/ark-os/config-defaults ]; then
+    /usr/lib/ark-os/venv/bin/python3 /usr/lib/ark-os/libexec/merge_configs.py \
+        /usr/lib/ark-os/config-defaults /var/lib/ark-os/.config-backup /etc/ark-os || true
+fi
+rm -rf /var/lib/ark-os/.config-backup
+
+# ===========================================================================
 # Step 3: Make /etc/ark-os group-writable by the service user so the web UI
 # (service-manager, running as $ARK_USER) can rewrite configs. Setgid on the
 # dir makes new files inherit the group. Re-applied on every install/upgrade
-# because the configs are plain package files, not conffiles.
+# because /etc/ark-os is populated by merge_configs.py, not the data tree.
 # ===========================================================================
 chgrp -R "$ARK_USER" /etc/ark-os
 chmod 2775 /etc/ark-os

--- a/packaging/DEBIAN/preinst
+++ b/packaging/DEBIAN/preinst
@@ -23,4 +23,14 @@ if [ -n "$have" ] && [ "$have" != "$want" ]; then
     echo "       Continuing anyway because ARK_OS_ALLOW_CODENAME_MISMATCH=1." >&2
 fi
 
+# On upgrade, snapshot the live configs before dpkg unpacks. The new package ships its
+# defaults under /usr/lib/ark-os/config-defaults (not /etc/ark-os), so dpkg removes the
+# old package's /etc/ark-os/* as obsolete during unpack; postinst's merge_configs.py
+# reads this snapshot to carry the user's values forward.
+if [ "$1" = "upgrade" ] && [ -d /etc/ark-os ]; then
+    rm -rf /var/lib/ark-os/.config-backup
+    mkdir -p /var/lib/ark-os/.config-backup
+    cp -a /etc/ark-os/. /var/lib/ark-os/.config-backup/ 2>/dev/null || true
+fi
+
 exit 0

--- a/packaging/assemble_tree.sh
+++ b/packaging/assemble_tree.sh
@@ -101,14 +101,21 @@ cp -r services/flight-review/flight_review/app "$PKG$ARK/flight-review/"
 # stray dev artifacts never ship in the .deb (the bundled venv's caches are kept).
 find "$PKG$ARK/flight-review" -type d -name __pycache__ -prune -exec rm -rf {} +
 
-# --- default configs -> /etc/ark-os ---
-install -m 0644 services/mavlink-router/main.conf "$PKG/etc/ark-os/mavlink-router.conf"
+# --- default config templates -> /usr/lib/ark-os/config-defaults ---
+# Shipped as templates rather than into /etc/ark-os so a dpkg upgrade never clobbers the
+# user's live configs; postinst's merge_configs.py reconciles them into /etc/ark-os (seed
+# on first install, value-preserving merge on upgrade). The empty /etc/ark-os dir created
+# above is the merge target.
+DEFAULTS="$PKG$ARK/config-defaults"
+mkdir -p "$DEFAULTS"
+install -m 0644 services/mavlink-router/main.conf "$DEFAULTS/mavlink-router.conf"
 for f in packaging/config/*; do
     base=$(basename "$f")
     # rid-transmitter is jetson-only; skip its config on pi.
     [ "$P" = "pi" ] && [ "$base" = "rid-transmitter.toml" ] && continue
-    install -m 0644 "$f" "$PKG/etc/ark-os/$base"
+    install -m 0644 "$f" "$DEFAULTS/$base"
 done
+install -m 0755 packaging/system-config/merge_configs.py "$PKG$ARK/libexec/merge_configs.py"
 
 # --- nginx site ---
 install -m 0644 frontend/ark-ui.nginx "$PKG/etc/nginx/sites-available/ark-ui"

--- a/packaging/system-config/merge_configs.py
+++ b/packaging/system-config/merge_configs.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Reconcile ARK-OS default config templates into /etc/ark-os, keeping user values.
+
+Run from postinst. For each template in DEFAULTS_DIR:
+  - seed the live config if it is absent (fresh install / brand-new file);
+  - otherwise overlay the user's current values onto the NEW template so that newly
+    added fields appear with their defaults, removed scalar fields drop out, and every
+    field the user still has keeps their value.
+
+The "user's current values" come from the pre-upgrade backup if present (preinst stashes
+/etc/ark-os there before dpkg can touch the live files), else the live file itself.
+
+Merge rule (see overlay()): template structure wins, user scalar/list values win, and
+user-added *sub-tables* (e.g. extra mavlink-router [UdpEndpoint ...] sections) are kept —
+only user-only *scalars* are pruned, since those are the removed schema fields.
+
+.toml is handled by the `toml` lib; .ini/.conf by configparser (case-preserving, no
+interpolation). Best-effort per file: a parse error seeds the template and logs a warning
+rather than aborting the upgrade. Exit status is always 0.
+"""
+import sys
+import os
+import shutil
+import configparser
+
+try:
+    import toml
+except Exception:
+    toml = None
+
+
+def _ini_parser() -> configparser.ConfigParser:
+    # optionxform=str: mavlink-router keys are CamelCase (TcpServerPort, FlowControl).
+    # interpolation=None: values may contain '%'. strict=False: tolerate odd input.
+    p = configparser.ConfigParser(interpolation=None, strict=False)
+    p.optionxform = str
+    return p
+
+
+def load(path: str):
+    """Return (kind, data) where data is a nested dict; kind in {'toml','ini'}."""
+    if path.endswith('.toml'):
+        if toml is None:
+            raise RuntimeError('toml library unavailable')
+        return 'toml', toml.load(path)
+    p = _ini_parser()
+    p.read(path)
+    return 'ini', {s: dict(p[s]) for s in p.sections()}
+
+
+def overlay(template, user):
+    """Template structure with the user's value wherever a key exists in both.
+
+    Keys only in the template (new) keep their default. User-only *scalars* are dropped
+    (removed schema fields); user-only *dicts* are kept (user-added sections/tables).
+    """
+    if isinstance(template, dict):
+        if not isinstance(user, dict):
+            return template  # schema changed shape -> take the new template
+        out = {}
+        for k, tv in template.items():
+            out[k] = overlay(tv, user[k]) if k in user else tv
+        for k, uv in user.items():
+            if k not in template and isinstance(uv, dict):
+                out[k] = uv  # user-added section/table -> preserve
+        return out
+    # leaf: keep the user's scalar/list unless the schema turned it into a table
+    return template if isinstance(user, dict) else user
+
+
+def dump(kind: str, data: dict, path: str) -> None:
+    tmp = path + '.tmp'
+    if kind == 'toml':
+        with open(tmp, 'w') as f:
+            toml.dump(data, f)
+    else:
+        p = _ini_parser()
+        for section, kv in data.items():
+            p[section] = {k: str(v) for k, v in kv.items()}
+        with open(tmp, 'w') as f:
+            p.write(f)
+    os.replace(tmp, path)  # atomic
+
+
+def main() -> int:
+    defaults_dir, user_dir, out_dir = sys.argv[1], sys.argv[2], sys.argv[3]
+    os.makedirs(out_dir, exist_ok=True)
+    for name in sorted(os.listdir(defaults_dir)):
+        template = os.path.join(defaults_dir, name)
+        if not os.path.isfile(template):
+            continue
+        out = os.path.join(out_dir, name)
+        # user's values: pre-upgrade backup wins, else the live file, else none (seed).
+        user = os.path.join(user_dir, name)
+        if not os.path.isfile(user):
+            user = out if os.path.isfile(out) else None
+        if user is None:
+            shutil.copyfile(template, out)
+            print(f"  seeded  {name}")
+            continue
+        try:
+            kind, tmpl = load(template)
+            _, usr = load(user)
+            dump(kind, overlay(tmpl, usr), out)
+            print(f"  merged  {name}")
+        except Exception as e:  # never break the upgrade over one bad file
+            shutil.copyfile(template, out)
+            print(f"  WARNING: merge failed for {name} ({e}); seeded default", file=sys.stderr)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary

A deb upgrade silently reset every UI-edited `/etc/ark-os/*` config to the packaged default. This ships the defaults as templates and reconciles them into `/etc/ark-os` on install/upgrade, preserving user values.

## Problem

The configs shipped in the package data tree under `/etc/ark-os` and were not registered as dpkg conffiles, so on upgrade dpkg overwrote them (and removed any that a later package dropped) — discarding whatever a customer had set through the web UI. Plain seed-if-absent would stop the clobber but never propagate newly added fields; plain overwrite loses values.

## Solution

Ship the defaults to `/usr/lib/ark-os/config-defaults` rather than `/etc/ark-os`, so dpkg never touches the live configs. `preinst` snapshots `/etc/ark-os` before unpack (dpkg removes the old package's copies as obsolete); `postinst` runs `merge_configs.py` under the bundled venv to seed on first install or, on upgrade, overlay the user's current values onto the new template — new fields take their defaults, removed scalar fields drop out, and user values plus user-added sections (e.g. extra mavlink-router `[UdpEndpoint …]` endpoints) are kept. `.toml` is handled by the `toml` lib, `.ini`/`.conf` by case-preserving configparser. The merge rule was verified locally across both formats (value preserved, field added, field pruned, user endpoint retained, seed-if-absent).
