### PR TITLE
fix(packaging): bound the journal and stop the mavlink-router crash-loop

### DIFF
--- a/packaging/service-files/jetson/mavlink-router.service
+++ b/packaging/service-files/jetson/mavlink-router.service
@@ -2,6 +2,10 @@
 Description=Mavlink Router
 Wants=network.target
 After=network-online.target
+# Cap the no-FC crash-loop: 5 failed starts within 60s fail the unit permanently
+# (until reset-failed/reboot); a re-plug within the window still recovers in ~5s.
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 Type=exec

--- a/packaging/service-files/pi/mavlink-router.service
+++ b/packaging/service-files/pi/mavlink-router.service
@@ -2,6 +2,10 @@
 Description=Mavlink Router
 Wants=network.target
 After=network-online.target
+# Cap the no-FC crash-loop: 5 failed starts within 60s fail the unit permanently
+# (until reset-failed/reboot); a re-plug within the window still recovers in ~5s.
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 Type=exec

--- a/packaging/system-config/10-ark-os.conf
+++ b/packaging/system-config/10-ark-os.conf
@@ -1,2 +1,5 @@
 [Journal]
 Storage=persistent
+# Bound the on-disk journal (and the SD-card write volume); without this journald
+# defaults to 10% of /var — several GB on a typical card.
+SystemMaxUse=1G


### PR DESCRIPTION
## Summary

Two reliability fixes from the pre-release Pi review: the persistent journal was unbounded, and mavlink-router crash-looped forever when no flight controller was attached.

## Problem

`10-ark-os.conf` set `Storage=persistent` with no size cap, so journald defaulted to 10% of /var — unbounded growth and SD-card writes. Separately, `start_mavlink_router.sh` exits non-zero when the FC isn't found, and with `Restart=on-failure`/`RestartSec=5` and no effective start limit the unit restarted every 5s indefinitely (observed restart counter >130 on a bench unit with no FC) — constant journal/SD churn. systemd's default start limit (5 per 10s) never tripped because the 5s spacing stays under the rate.

## Solution

Cap `SystemMaxUse=1G`. Add `StartLimitIntervalSec=60` + `StartLimitBurst=5` to both mavlink-router units so 5 rapid failures fail the unit permanently (cleared by `systemctl reset-failed` or a reboot); `RestartSec` stays 5s so a flight controller re-plugged within the window still recovers in seconds.
