### PR TITLE
fix(services): restore localhost binds missing from v1.0.2

### DIFF
--- a/services/ark-ui-backend/index.js
+++ b/services/ark-ui-backend/index.js
@@ -8,6 +8,9 @@ const http = require('http');
 const app = express();
 const server = http.createServer(app);
 const PORT = process.env.PORT || 3000;
+// Bind localhost: the public surface is nginx :80, which proxies /api/* here.
+// Set HOST=0.0.0.0 only if a direct, non-nginx consumer truly needs the gateway.
+const HOST = process.env.HOST || '127.0.0.1';
 
 // Apply middleware that doesn't interfere with request body
 app.use(morgan('dev')); // Logging for HTTP requests
@@ -120,8 +123,8 @@ app.use((err, req, res, next) => {
 });
 
 // Start the server
-server.listen(PORT, () => {
-  console.log(`API Gateway running on port ${PORT}`);
+server.listen(PORT, HOST, () => {
+  console.log(`API Gateway running on ${HOST}:${PORT}`);
 });
 
 module.exports = { app, server };

--- a/services/autopilot-manager/autopilot_manager.py
+++ b/services/autopilot-manager/autopilot_manager.py
@@ -860,8 +860,10 @@ def parse_arguments():
                         default='udpin:localhost:14571',
                         help='MAVLink connection string (default: udpin:localhost:14571)')
     parser.add_argument('--host',
-                        default='0.0.0.0',
-                        help='Host address to bind (default: 0.0.0.0)')
+                        # localhost only: reached via the nginx gateway (localhost:3003),
+                        # never a public surface — matches the other managers.
+                        default='127.0.0.1',
+                        help='Host address to bind (default: 127.0.0.1)')
     parser.add_argument('--port',
                         type=int,
                         default=int(os.environ.get('PORT', 3003)),


### PR DESCRIPTION
## Summary

Re-applies the localhost bind hardening from #77, which was lost when that PR was squash-merged — v1.0.2 shipped with autopilot-manager and the gateway still bound to all interfaces.

## Problem

#77's squash commit captured only the polkit and frontend changes; the bind commit added later (autopilot-manager + gateway → 127.0.0.1) was not part of the squash, so v1.0.2 leaves the autopilot API (`:3003`) and the gateway (`:3000`) reachable on every interface, including the Wi-Fi AP. Confirmed on the Pi after upgrading to v1.0.2: `:3003` and `:3000` still bind `0.0.0.0`.

## Solution

Cherry-pick the original bind commit: autopilot-manager defaults `--host` to `127.0.0.1`, and the gateway binds `127.0.0.1` (honoring `HOST=0.0.0.0` as an opt-in). The public surface stays nginx `:80`.
