### PR TITLE
fix(services): restart a failed/given-up service from the UI

### DIFF
--- a/frontend/src/pages/ServicesPage.vue
+++ b/frontend/src/pages/ServicesPage.vue
@@ -19,7 +19,7 @@
             <button v-if="service.active === 'active'" @click="stopService(service.name)" title="Stop service">
               <i class="fas fa-stop"></i>
             </button>
-            <button v-if="service.active === 'inactive'" @click="startService(service.name)" title="Start service">
+            <button v-if="service.active !== 'active'" @click="startService(service.name)" title="Start service">
               <i class="fas fa-play"></i>
             </button>
             <button @click="openLogViewer(service.name)" title="View journal logs">

--- a/services/service-manager/service_manager.py
+++ b/services/service-manager/service_manager.py
@@ -187,6 +187,9 @@ class ServiceManager:
 
     @staticmethod
     def start_service(service_name: str) -> ActionResponse:
+        # Clear any failed / start-limit-hit state first, so a unit that gave up
+        # (e.g. mavlink-router hitting its StartLimit with no FC) starts from the UI.
+        ServiceManager.run_systemctl("reset-failed", service_name)
         success, message = ServiceManager.run_systemctl("start", service_name)
 
         if success:


### PR DESCRIPTION
## Summary

After mavlink-router's StartLimit give-up (added in v1.0.2/v1.0.3) leaves a service in `failed`, the web UI offered no way to restart it. This restores that.

## Problem

The Services page rendered a Start button only for `service.active === 'inactive'`, so a `failed` unit — e.g. mavlink-router after giving up with no flight controller — showed neither Start nor Stop, and couldn't be recovered from the UI. And even with a button, `systemctl start` is refused on a unit that hit its StartLimit until `reset-failed` runs, so the start path would have no-opped anyway.

## Solution

Show the Start button for any non-running state (`service.active !== 'active'`), and have `start_service` run `systemctl reset-failed` before `start`. Verified on the device that `reset-failed` is authorized for the service user via the existing per-unit `manage-units` polkit grant, and that the sequence relaunches a given-up unit with its restart counter reset to 0.
