### PR TITLE
docs(readme): add ARK Just a Pi to supported targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ ARK-OS is a collection of software services and tools for drones. These services
 #### Supported targets
 - **ARK Jetson Carrier** <br> https://arkelectron.com/product/ark-jetson-pab-carrier/
 - **ARK Pi6X Flow** <br> https://arkelectron.com/product/ark-pi6x-flow/
+- **ARK Just a Pi** <br> https://arkelectron.com/product/ark-just-a-pi/
 
 # Getting started
 If you haven't set up an internet connection on your device, ssh in and connect to your wifi network.


### PR DESCRIPTION
## Summary
Add the ARK Just a Pi carrier board to the list of supported targets in the README.

## Problem
The README's supported-targets list did not include the ARK Just a Pi carrier board (https://arkelectron.com/product/ark-just-a-pi/), a Raspberry Pi Compute Module 5 carrier that ARK-OS runs on via the Pi packages.

## Solution
Add it as a third bullet under **Supported targets**, matching the existing name + product-link format.