### PR TITLE
fix(services): cut idle CPU churn and per-request log spam

### DIFF
--- a/services/ark-ui-backend/index.js
+++ b/services/ark-ui-backend/index.js
@@ -12,8 +12,10 @@ const PORT = process.env.PORT || 3000;
 // Set HOST=0.0.0.0 only if a direct, non-nginx consumer truly needs the gateway.
 const HOST = process.env.HOST || '127.0.0.1';
 
-// Apply middleware that doesn't interfere with request body
-app.use(morgan('dev')); // Logging for HTTP requests
+// Apply middleware that doesn't interfere with request body.
+// Behind nginx (which already logs requests), only surface problems here so the
+// UI's 1 Hz polling doesn't flood the journal — log 4xx/5xx responses only.
+app.use(morgan('tiny', { skip: (req, res) => res.statusCode < 400 }));
 app.use(cors());
 
 // Configuration for our microservices (with default values)
@@ -28,16 +30,11 @@ console.log(`- SERVICE_MANAGER_URL: ${SERVICE_MANAGER_URL}`);
 console.log(`- AUTOPILOT_SERVICE_URL: ${AUTOPILOT_SERVICE_URL}`);
 console.log(`- SYSTEM_SERVICE_URL: ${SYSTEM_SERVICE_URL}`);
 
-app.use((req, res, next) => {
-  console.log(`[${req.method}] ${req.originalUrl}`);
-  next();
-});
-
 // Service proxy
 app.use('/api/service', createProxyMiddleware({
   target: SERVICE_MANAGER_URL,
   changeOrigin: true,
-  logLevel: 'debug',
+  logLevel: 'warn',
   onError: (err, req, res) => {
     console.error(`Service proxy error: ${err.message}`);
     res.writeHead(502, { 'Content-Type': 'application/json' });
@@ -49,7 +46,7 @@ app.use('/api/service', createProxyMiddleware({
 app.use('/api/network', createProxyMiddleware({
   target: NETWORK_SERVICE_URL,
   changeOrigin: true,
-  logLevel: 'debug',
+  logLevel: 'warn',
   onError: (err, req, res) => {
     console.error(`Network proxy error: ${err.message}`);
     res.writeHead(502, { 'Content-Type': 'application/json' });
@@ -61,7 +58,7 @@ app.use('/api/network', createProxyMiddleware({
 app.use('/api/autopilot', createProxyMiddleware({
   target: AUTOPILOT_SERVICE_URL,
   changeOrigin: true,
-  logLevel: 'debug',
+  logLevel: 'warn',
   onError: (err, req, res) => {
     console.error(`Autopilot service proxy error: ${err.message}`);
     res.writeHead(502, { 'Content-Type': 'application/json' });
@@ -73,7 +70,7 @@ app.use('/api/autopilot', createProxyMiddleware({
 app.use('/api/system', createProxyMiddleware({
   target: SYSTEM_SERVICE_URL,
   changeOrigin: true,
-  logLevel: 'debug',
+  logLevel: 'warn',
   onError: (err, req, res) => {
     console.error(`System service proxy error: ${err.message}`);
     res.writeHead(502, { 'Content-Type': 'application/json' });
@@ -83,14 +80,6 @@ app.use('/api/system', createProxyMiddleware({
 
 // NOW add body parsing middleware AFTER all proxies
 app.use(express.json());
-
-// Add body logging middleware after body parser
-app.use((req, res, next) => {
-  if (req.body && Object.keys(req.body).length > 0) {
-    console.log(`Request body:`, req.body);
-  }
-  next();
-});
 
 // Health check endpoint and other non-proxy endpoints
 app.get('/health', (req, res) => {

--- a/services/autopilot-manager/autopilot_manager.py
+++ b/services/autopilot-manager/autopilot_manager.py
@@ -155,6 +155,12 @@ class DeviceDetector:
 
 
 class MAVLinkConnection:
+    # Reconnect backoff bounds (seconds) for when the autopilot heartbeat is
+    # absent: rebuild the link on a growing delay instead of churning the socket
+    # every few seconds on a board with no flight controller.
+    _INITIAL_RESET_BACKOFF = 1.0
+    _MAX_RESET_BACKOFF = 30.0
+
     def __init__(self, connection_string='udpin:localhost:14571', source_system=254):
         self.connection_string = connection_string
         self.source_system = source_system
@@ -229,6 +235,16 @@ class MAVLinkConnection:
             autoreconnect=True,
             source_system=self.source_system)
 
+    def _reconnect_helps(self) -> bool:
+        """Whether rebuilding the connection can actually recover the link.
+
+        A udpin/udp listener has no peer to dial, so recreating its socket while
+        the FC is gone only churns it — the existing socket still receives a
+        returning autopilot. Client/serial links (udpout, tcp, serial) do
+        benefit from a rebuild.
+        """
+        return not self.connection_string.startswith(('udpin:', 'udp:'))
+
     def update_heartbeat_time(self):
         """Update the last heartbeat timestamp"""
         self.last_heartbeat = datetime.now()
@@ -296,11 +312,16 @@ class MAVLinkConnection:
     def process_messages(self):
         """Process incoming MAVLink messages in a loop"""
         self.running = True
-        connection_attempts = 0
         last_version_request_time = 0.0
         last_system_time_update_time = 0.0
         last_device_check_time = 0.0
-        waiting_for_heartbeat = True
+        last_probe_time = 0.0
+        # Reconnect/episode state: back off rebuilding the link, and log the
+        # disconnect only once per episode (not every loop) so an FC-less board
+        # doesn't churn the socket or flood the journal.
+        reset_backoff = self._INITIAL_RESET_BACKOFF
+        next_reset_time = 0.0
+        disconnect_logged = False
 
         while self.running:
             try:
@@ -324,9 +345,6 @@ class MAVLinkConnection:
                     if msg.get_srcComponent() != mavlink.MAV_COMP_ID_AUTOPILOT1:
                         continue
 
-                    # We received a message, connection is working
-                    waiting_for_heartbeat = False
-
                     # Process different message types
                     if msg.get_type() == 'HEARTBEAT':
                         self.update_heartbeat_time()
@@ -334,8 +352,13 @@ class MAVLinkConnection:
                             self.autopilot_data["autopilot_type"] = self.get_autopilot_type(msg.autopilot)
                             self.autopilot_data["mavlink_connected"] = True
 
-                        # Reset connection attempts on successful heartbeat
-                        connection_attempts = 0
+                        # Recovered: log once and reset the backoff so the next
+                        # drop is reported promptly and probed without delay.
+                        if disconnect_logged:
+                            logger.info("Autopilot heartbeat received; MAVLink connected")
+                            disconnect_logged = False
+                        reset_backoff = self._INITIAL_RESET_BACKOFF
+                        next_reset_time = 0.0
 
                         # Periodically request version information if needed
                         if current_time - last_version_request_time > 5:
@@ -380,35 +403,44 @@ class MAVLinkConnection:
                             if hasattr(msg, 'battery_remaining'):
                                 self.autopilot_data["remaining"] = msg.battery_remaining
 
-                # If no message or heartbeat timeout occurred, check connection status
+                # No message, and the autopilot heartbeat is missing or stale.
                 elif (self.last_heartbeat is None or
                       (datetime.now() - self.last_heartbeat).total_seconds() > 5):
 
                     with self._lock:
                         self.autopilot_data["mavlink_connected"] = False
 
-                    # No recent heartbeat, try to send one to elicit a response
-                    if waiting_for_heartbeat and connection_attempts < 5:
+                    # Log the disconnect once per episode, not every cycle — a
+                    # board with no FC would otherwise WARN every few seconds.
+                    if not disconnect_logged:
+                        logger.warning("No autopilot heartbeat; probing and reconnecting in the background")
+                        disconnect_logged = True
+
+                    # Probe with a GCS heartbeat at ~1 Hz to elicit a response.
+                    if current_time - last_probe_time >= 1.0:
                         try:
-                            logger.debug(f"Sending heartbeat attempt {connection_attempts+1}/5")
                             self.mav_connection.mav.heartbeat_send(
                                 mavlink.MAV_TYPE_GCS,
                                 mavlink.MAV_AUTOPILOT_INVALID,
                                 0, 0, 0)
-                            connection_attempts += 1
                         except Exception as e:
                             logger.error(f"Error sending heartbeat: {e}")
-                    # If we've tried several times, reset the connection
-                    elif connection_attempts >= 5:
-                        try:
-                            logger.warning("Connection issues detected, attempting to reset MAVLink connection")
-                            self._reset_connection()
-                            waiting_for_heartbeat = True
-                            connection_attempts = 0
-                        except Exception as reset_error:
-                            logger.error(f"Error resetting MAVLink connection: {reset_error}")
-                            self.mav_connection = None
-                            time.sleep(1)
+                        last_probe_time = current_time
+
+                    # Rebuild the link on a capped exponential backoff so a
+                    # permanently absent FC can't churn the socket (or journal)
+                    # every few seconds. Skipped entirely for a udpin listener,
+                    # which has no peer to reconnect to.
+                    if current_time >= next_reset_time:
+                        if self._reconnect_helps():
+                            try:
+                                self._reset_connection()
+                            except Exception as reset_error:
+                                logger.error(f"Error resetting MAVLink connection: {reset_error}")
+                                self.mav_connection = None
+                                time.sleep(1)
+                        next_reset_time = current_time + reset_backoff
+                        reset_backoff = min(reset_backoff * 2, self._MAX_RESET_BACKOFF)
 
             except socket.timeout:
                 # This is expected when using blocking mode with timeout
@@ -420,8 +452,8 @@ class MAVLinkConnection:
                 time.sleep(1)
                 try:
                     self._reset_connection()
-                    waiting_for_heartbeat = True
-                    connection_attempts = 0
+                    reset_backoff = self._INITIAL_RESET_BACKOFF
+                    next_reset_time = current_time + reset_backoff
                 except Exception as reset_error:
                     logger.error(f"Error resetting MAVLink connection: {reset_error}")
                     self.mav_connection = None

--- a/services/service-manager/service_manager.py
+++ b/services/service-manager/service_manager.py
@@ -19,10 +19,24 @@ import os
 import json
 import subprocess
 import re
+import logging
 
 from fastapi import FastAPI
 from pydantic import BaseModel
 import uvicorn
+
+
+def setup_logging():
+    """Setup simple logging that will be captured by journald via stdout"""
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        handlers=[logging.StreamHandler()]
+    )
+    return logging.getLogger('service-manager')
+
+
+logger = setup_logging()
 
 
 # ── HTTP contract: the single source of truth ────────────────────────────────
@@ -139,7 +153,7 @@ class ServiceManager:
                     manifest_data = json.load(f)
                     config_file_name = manifest_data.get("configFile", "") or ""
             except Exception as e:
-                print(f"Error reading manifest file for {service_name}: {e}")
+                logger.error(f"Error reading manifest file for {service_name}: {e}")
 
         return os.path.join(CONFIG_DIR, config_file_name)
 
@@ -158,6 +172,47 @@ class ServiceManager:
         return True
 
     @staticmethod
+    def _query_unit_states(service_names: list[str]) -> dict[str, tuple[str, str]]:
+        """Return {service: (enabled_state, active_state)} for many units in a
+        single `systemctl show` call.
+
+        Replaces two `systemctl` spawns *per service*: with the UI polling
+        /statuses at up to 1 Hz, that was ~2xN subprocess launches every second.
+        UnitFileState/ActiveState carry the same vocabulary as is-enabled/
+        is-active, so the values the UI sees are unchanged.
+        """
+        states: dict[str, tuple[str, str]] = {}
+        if not service_names:
+            return states
+
+        units = [f"{name}.service" for name in service_names]
+        try:
+            process = subprocess.run(
+                ["systemctl", "show", "-p", "Id", "-p", "UnitFileState", "-p", "ActiveState", *units],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except Exception as e:
+            logger.error(f"Error querying unit states: {e}")
+            return states
+
+        # One blank-line-separated block per unit, each a set of Key=Value lines.
+        for block in process.stdout.strip().split("\n\n"):
+            props: dict[str, str] = {}
+            for line in block.splitlines():
+                key, _, value = line.partition("=")
+                props[key] = value
+            unit_id = props.get("Id", "")
+            if unit_id.endswith(".service"):
+                name = unit_id[: -len(".service")]
+                states[name] = (
+                    props.get("UnitFileState") or "unknown",
+                    props.get("ActiveState") or "unknown",
+                )
+        return states
+
+    @staticmethod
     def get_service_statuses() -> ServiceList:
         services = []
 
@@ -165,12 +220,13 @@ class ServiceManager:
             return ServiceList(services=[])
 
         manifest_files = [f for f in os.listdir(MANIFEST_DIR) if f.endswith('.manifest.json')]
+        service_names = [f[:-len('.manifest.json')] for f in manifest_files]
 
-        for manifest_file in manifest_files:
-            service_name = manifest_file[:-len('.manifest.json')]
+        # One batched systemctl call for all units instead of two spawns each.
+        unit_states = ServiceManager._query_unit_states(service_names)
 
-            enabled_status = ServiceManager.get_service_status(service_name, "enabled")
-            active_status = ServiceManager.get_service_status(service_name, "active")
+        for service_name in service_names:
+            enabled_status, active_status = unit_states.get(service_name, ("unknown", "unknown"))
 
             config_file = ServiceManager.get_service_config_file(service_name)
             config_file_name = os.path.basename(config_file) if os.path.isfile(config_file) else ""
@@ -309,55 +365,55 @@ class ServiceManager:
 
 @app.get("/statuses")
 def get_service_statuses() -> ServiceList:
-    print("GET /statuses called")
+    logger.debug("GET /statuses called")
     return ServiceManager.get_service_statuses()
 
 
 @app.post("/start", response_model_exclude_none=True)
 def start_service(serviceName: str) -> ActionResponse:
-    print(f"POST /start called for {serviceName}")
+    logger.info(f"POST /start called for {serviceName}")
     return ServiceManager.start_service(serviceName)
 
 
 @app.post("/stop", response_model_exclude_none=True)
 def stop_service(serviceName: str) -> ActionResponse:
-    print(f"POST /stop called for {serviceName}")
+    logger.info(f"POST /stop called for {serviceName}")
     return ServiceManager.stop_service(serviceName)
 
 
 @app.post("/restart", response_model_exclude_none=True)
 def restart_service(serviceName: str) -> ActionResponse:
-    print(f"POST /restart called for {serviceName}")
+    logger.info(f"POST /restart called for {serviceName}")
     return ServiceManager.restart_service(serviceName)
 
 
 @app.post("/enable", response_model_exclude_none=True)
 def enable_service(serviceName: str) -> ActionResponse:
-    print(f"POST /enable called for {serviceName}")
+    logger.info(f"POST /enable called for {serviceName}")
     return ServiceManager.enable_service(serviceName)
 
 
 @app.post("/disable", response_model_exclude_none=True)
 def disable_service(serviceName: str) -> ActionResponse:
-    print(f"POST /disable called for {serviceName}")
+    logger.info(f"POST /disable called for {serviceName}")
     return ServiceManager.disable_service(serviceName)
 
 
 @app.get("/logs", response_model_exclude_none=True)
 def get_service_logs(serviceName: str) -> LogsResponse:
-    print(f"GET /logs called for {serviceName}")
+    logger.debug(f"GET /logs called for {serviceName}")
     return ServiceManager.get_logs(serviceName)
 
 
 @app.get("/config")
 def get_service_config(serviceName: str) -> ConfigResponse:
-    print(f"GET /config called for {serviceName}")
+    logger.info(f"GET /config called for {serviceName}")
     return ServiceManager.get_config(serviceName)
 
 
 @app.post("/config")
 def save_service_config(serviceName: str, body: SaveConfigRequest) -> ConfigResponse:
-    print(f"POST /config called for {serviceName}")
+    logger.info(f"POST /config called for {serviceName}")
 
     if not body.config:
         return ConfigResponse(status="fail", data="No configuration data provided")
@@ -369,6 +425,6 @@ if __name__ == '__main__':
     host = '127.0.0.1'
     port = int(os.environ.get("PORT", 3002))
 
-    print(f"Starting Service Manager on {host}:{port}")
+    logger.info(f"Starting Service Manager on {host}:{port}")
     # access_log off: the UI polls /statuses.
     uvicorn.run(app, host=host, port=port, access_log=False)

--- a/services/system-manager/system_manager.py
+++ b/services/system-manager/system_manager.py
@@ -115,6 +115,10 @@ class SystemInfoCollector:
     @staticmethod
     def get_common_info() -> dict[str, Any]:
         """Get system information common to all devices"""
+        # Sample each source once; virtual_memory()/disk_usage() each shell into
+        # the kernel, so calling them per-field was four redundant probes apiece.
+        vm = psutil.virtual_memory()
+        du = psutil.disk_usage('/')
         info: dict[str, Any] = {
             "hostname": platform.node(),
             "python_version": platform.python_version(),
@@ -122,16 +126,16 @@ class SystemInfoCollector:
             "architecture": platform.machine(),
             "cpu_count": psutil.cpu_count(),
             "memory": {
-                "total": psutil.virtual_memory().total / (1024**3),  # GB
-                "used": psutil.virtual_memory().used / (1024**3),
-                "available": psutil.virtual_memory().available / (1024**3),
-                "percent": psutil.virtual_memory().percent
+                "total": vm.total / (1024**3),  # GB
+                "used": vm.used / (1024**3),
+                "available": vm.available / (1024**3),
+                "percent": vm.percent
             },
             "disk": {
-                "total": psutil.disk_usage('/').total / (1024**3),
-                "used": psutil.disk_usage('/').used / (1024**3),
-                "available": psutil.disk_usage('/').free / (1024**3),
-                "percent": psutil.disk_usage('/').percent
+                "total": du.total / (1024**3),
+                "used": du.used / (1024**3),
+                "available": du.free / (1024**3),
+                "percent": du.percent
             },
             "network_interfaces": {}
         }


### PR DESCRIPTION
## Summary
Reduce continuous background work across the ARK-OS services, found during a live + source audit on a Just-a-Pi. Targets needless MAVLink socket/log churn, a 1 Hz poll that fanned out ~22 subprocesses/second, and duplicate per-request logging. Nothing the UI consumes changes.

## Problem
On an idle device (no FC attached) the services were healthy CPU-wise but doing avoidable work that wastes CPU and writes tens of thousands of journal lines/day (SD-card wear):
- **autopilot-manager** rebuilt its `udpin` socket and logged a WARNING every ~3s forever (~29k lines/day) — a reconnect loop with no backoff, on a listener that has no peer to reconnect to.
- **service-manager** `/statuses` spawned `systemctl is-enabled` + `is-active` per service; the UI polls it at up to 1 Hz (~22 `systemctl` forks/second) and `print()`d on every call.
- **ark-ui-backend** logged every proxied request twice (morgan + a custom middleware) with the proxies at `logLevel: 'debug'`, and printed raw request bodies (including WiFi PSKs).
- **system-manager** sampled psutil memory/disk four times each per `/info`.

No memory or descriptor leaks were found: autopilot-manager held steady at 8 fds / 6 threads across 1,952 socket resets, and RSS was flat.

## Solution
- **autopilot-manager**: log the disconnect once per episode, probe at 1 Hz, rebuild on a capped exponential backoff (1→30s), and skip the rebuild entirely for a `udpin`/`udp` listener.
- **service-manager**: collect every unit's state in a single `systemctl show` call (37 ms vs 131 ms on a Pi 5; 1 spawn vs 22) and route per-call logging through a level-gated logger (`/statuses`, `/logs` at debug).
- **ark-ui-backend**: log only 4xx/5xx via morgan, drop the redundant request logger, lower proxies to `warn`, and remove the body logger that leaked secrets.
- **system-manager**: sample `virtual_memory()`/`disk_usage()` once per `/info`.

Verified: `mypy` clean on all four migrated services, `node --check` clean, and the batched `systemctl show` output validated against the device.