### PR TITLE
fix(packaging): restart running services on package upgrade

### DIFF
--- a/packaging/DEBIAN/postinst
+++ b/packaging/DEBIAN/postinst
@@ -274,6 +274,19 @@ if [ -d /run/systemd/system ]; then
 
     systemctl start ark-os.target 2>/dev/null || true
 
+    # On upgrade ($2 = previously-configured version), restart the already-running
+    # ARK-OS services so the new package's code replaces the running processes.
+    # `systemctl start ark-os.target` above does NOT achieve this: the units are
+    # WantedBy= (not PartOf=) the target, so starting/stopping/restarting the
+    # target never propagates to a unit that is already active — it just stays up
+    # on the old code. try-restart only touches currently-active units, so a
+    # failed (e.g. mavlink-router with no FC) or operator-stopped service is
+    # left as-is rather than force-started.
+    if [ -n "$2" ]; then
+        RESTART_SERVICES="$ENABLE_SERVICES dds-agent logloader polaris flight-review rid-transmitter"
+        systemctl try-restart $RESTART_SERVICES 2>/dev/null || true
+    fi
+
     if nginx -t 2>/dev/null; then
         systemctl reload nginx 2>/dev/null || true
     fi


### PR DESCRIPTION
## Summary
A package upgrade refreshed the service files on disk but left the previous processes running, so changes only took effect after a reboot. Restart the running ARK-OS services in postinst on upgrade.

## Problem
prerm/postinst manage the service group via `systemctl stop`/`start ark-os.target`. But the units are wired with `WantedBy=ark-os.target` — a start-only dependency — and stop/restart of a target only propagates to `PartOf=`/`BindsTo=` members. Confirmed on a device: `ark-os.target` reports `ConsistsOf=` empty and each service reports `PartOf=` empty. So `stop ark-os.target` is a no-op for the running services and `start ark-os.target` finds them already active — the pre-upgrade processes survive the upgrade still running the old code.

## Solution
In postinst's runtime block, on upgrade (`$2` = previously-configured version), `systemctl try-restart` the ARK-OS services so the new code replaces the running processes. `try-restart` only acts on units that are currently running, so services that ship disabled (dds-agent, logloader, polaris, flight-review, rid-transmitter) — or that the operator stopped — are left untouched, never started. Fresh installs are unaffected: they still come up via the existing `start ark-os.target`.