### PR TITLE
fix(packaging): stop services on package removal

### DIFF
--- a/packaging/DEBIAN/prerm
+++ b/packaging/DEBIAN/prerm
@@ -1,10 +1,26 @@
 #!/bin/sh
-# Stop the whole ARK-OS service group before the package files are removed or
-# replaced. One command covers every enabled unit (via ark-os.target).
+# Stop the ARK-OS services on package removal.
+#
+# The previous `systemctl stop ark-os.target` was a no-op for the services: they
+# are WantedBy= the target, not PartOf=, so stopping the target never propagates
+# to its members — `apt remove` left every service running with its files deleted
+# out from under it. Stop the units explicitly instead.
+#
+# On *upgrade* we deliberately do NOT stop here: postinst try-restarts the
+# services after the new files are unpacked, which keeps the web UI / MAVLink
+# routing up during the unpack rather than down for its whole duration.
 set -e
 
-if [ -d /run/systemd/system ]; then
-    systemctl stop ark-os.target 2>/dev/null || true
-fi
+# Platform-specific units (jetson-can, rid-transmitter) are simply not loaded on
+# the other platform, so stopping them there is a harmless no-op.
+ARK_SERVICES="mavlink-router rtsp-server ark-ui-backend autopilot-manager connection-manager service-manager system-manager dds-agent logloader polaris flight-review rid-transmitter jetson-can"
+
+case "$1" in
+    remove)
+        if [ -d /run/systemd/system ]; then
+            systemctl stop $ARK_SERVICES ark-os.target 2>/dev/null || true
+        fi
+        ;;
+esac
 
 exit 0


### PR DESCRIPTION
## Summary
`apt remove` left every ARK-OS service running with its files deleted. Stop them explicitly in prerm on removal.

## Problem
prerm stopped the group with `systemctl stop ark-os.target`, but the units are `WantedBy=ark-os.target` — a start-only dependency — and stopping a target only propagates to `PartOf=`/`BindsTo=` members. Confirmed on a device: `ark-os.target` reports `ConsistsOf=` empty and each service reports `PartOf=` empty. So the stop was a no-op and removal left the services running against deleted binaries/configs until the next reboot. Same root cause as #85, which fixed the upgrade side.

## Solution
Stop the ARK-OS units explicitly on `remove`. Upgrade is deliberately left alone: postinst (#85) try-restarts the services after the new files are unpacked, which keeps the web UI and MAVLink routing up during the unpack instead of taking them down for its whole duration. This is also the conventional split — stop on remove in prerm, restart on upgrade in postinst — and avoids giving the units `PartOf=ark-os.target`, which would have coupled removal and upgrade (firing the prerm stop on upgrade too).