### PR TITLE
fix(packaging): disable systemd-time-wait-sync so offline boots do not hang

### DIFF
--- a/packaging/DEBIAN/postinst
+++ b/packaging/DEBIAN/postinst
@@ -221,8 +221,10 @@ systemctl enable ark-os.target 2>/dev/null || true
 for svc in $ENABLE_SERVICES; do
     systemctl enable "$svc.service" 2>/dev/null || true
 done
-# Jetsons typically have no RTC; gate time-dependent services on NTP convergence.
-systemctl enable systemd-time-wait-sync.service 2>/dev/null || true
+# Don't gate boot on time sync: systemd-time-wait-sync has an infinite start timeout,
+# so an RTC-less Jetson booting offline wedges until NTP converges (never, with no net).
+# timesyncd still corrects the clock once a network is up.
+systemctl disable systemd-time-wait-sync.service 2>/dev/null || true
 # First-boot finalization (default hotspot, flight-review DB, Wi-Fi unblock). Enabled
 # so a chroot-built image runs it on first boot; a live install also kicks it below.
 systemctl enable ark-os-firstboot.service 2>/dev/null || true


### PR DESCRIPTION
## Summary
Provisioned Jetsons hang at boot when offline — nothing in `multi-user.target` starts (jtop, mavlink-router, all ark-os services). The cause is the postinst enabling `systemd-time-wait-sync.service`.

## Problem
The postinst enabled `systemd-time-wait-sync.service` to gate time-dependent services on NTP convergence (Jetsons usually have no RTC). That unit ships with `TimeoutStartUSec=infinity` and is ordered `Before=time-sync.target` on the boot-critical path, so when no NTP server is reachable — a USB-only bench, or a vehicle in the field — it never completes. `systemctl is-system-running` stays `starting`, `multi-user.target` is never reached, and every service behind it is stranded. Enabling it also overrode the stock systemd preset, which ships this unit disabled.

## Solution
Disable `systemd-time-wait-sync.service` in the postinst instead of enabling it, so boot never blocks on time sync; `systemd-timesyncd` still corrects the clock once a network is available. For plausible timestamps across reboots without an RTC, `fake-hwclock` is the appropriate follow-up (separate change).
