### PR TITLE
feat(service-logs): stream service logs as a live tail over SSE

### DIFF
--- a/frontend/src/pages/components/LogViewer.vue
+++ b/frontend/src/pages/components/LogViewer.vue
@@ -1,10 +1,26 @@
 <template>
-  <div class="log-viewer-backdrop">
+  <div class="log-viewer-backdrop" @click.self="closeViewer">
     <div class="log-viewer-container">
-      <h2>{{ serviceName }}</h2>
-      <pre class="log-content" ref="logContent">
-        {{ logs }}
-      </pre>
+      <div class="log-header">
+        <h2>{{ serviceName }}</h2>
+        <span class="live-status" :class="{ live: connected }">
+          <span class="dot"></span>{{ connected ? 'live' : 'reconnecting…' }}
+        </span>
+      </div>
+
+      <div class="log-body" ref="logBody" @scroll="onScroll">
+        <div v-if="errorMessage" class="log-error">{{ errorMessage }}</div>
+        <div v-else-if="lines.length === 0" class="log-empty">Waiting for log output…</div>
+        <div v-for="line in lines" :key="line.id" class="log-row">
+          <span class="log-ts" :title="formatFull(line.ts)">{{ formatTime(line.ts) }}</span>
+          <span class="log-msg" :class="priorityClass(line.priority)">{{ line.message }}</span>
+        </div>
+      </div>
+
+      <button v-if="!stickToBottom" class="jump-button" @click="jumpToBottom">
+        Jump to latest ↓
+      </button>
+
       <div class="actions">
         <button @click="closeViewer" class="close-button">Close</button>
       </div>
@@ -13,73 +29,137 @@
 </template>
 
 <script>
-import axios from 'axios';
+// Keep memory bounded on long-lived streams; the newest lines are what matters.
+const MAX_LINES = 2000;
+// Treat "within this many px of the bottom" as actively following the tail.
+const STICK_THRESHOLD = 24;
 
 export default {
   props: ['serviceName'],
   data() {
     return {
-      logs: '',
-      logPollingInterval: null
+      lines: [],
+      logSource: null,
+      connected: false,
+      errorMessage: '',
+      stickToBottom: true,
+      nextId: 0,
     };
   },
   mounted() {
-    this.startPolling();
+    this.connectStream();
   },
   beforeUnmount() {
-    this.stopPolling();
+    this.disconnectStream();
   },
   methods: {
-    fetchLogs() {
-      axios.get(`/api/service/logs?serviceName=${this.serviceName}`)
-        .then(response => {
-          if (response.data.status === 'success') {
-            this.logs = response.data.logs;
-          } else {
-            console.error('Error fetching logs:', response.data.message);
-          }
-        })
-        .catch(error => {
-          console.error('Error fetching logs:', error);
-        });
+    connectStream() {
+      this.disconnectStream();
+
+      const url = `/api/service/logs/stream?serviceName=${encodeURIComponent(this.serviceName)}`;
+      const source = new EventSource(url);
+      this.logSource = source;
+
+      source.onopen = () => {
+        // The backend re-seeds the last 200 lines on every (re)connect, so clear
+        // first to avoid duplicating history after an automatic reconnect.
+        this.lines = [];
+        this.connected = true;
+        this.errorMessage = '';
+        this.stickToBottom = true;
+      };
+
+      source.addEventListener('log_line', (event) => {
+        let entry;
+        try {
+          entry = JSON.parse(event.data);
+        } catch {
+          return;
+        }
+        this.appendLine(entry);
+      });
+
+      source.addEventListener('log_error', (event) => {
+        try {
+          this.errorMessage = JSON.parse(event.data).message || 'Log stream error';
+        } catch {
+          this.errorMessage = 'Log stream error';
+        }
+        // The backend closes after an error event; stop EventSource from
+        // reconnecting in a loop against an unmanaged service.
+        this.disconnectStream();
+        this.connected = false;
+      });
+
+      source.onerror = () => {
+        // Connection-level error only; EventSource reconnects on its own.
+        this.connected = false;
+      };
     },
-    startPolling() {
-      this.fetchLogs(); // Initial fetch
-      this.logPollingInterval = setInterval(() => {
-        this.fetchLogs();
-      }, 1000); // Poll every second
-    },
-    stopPolling() {
-      if (this.logPollingInterval) {
-        clearInterval(this.logPollingInterval);
+
+    appendLine(entry) {
+      this.lines.push({ id: this.nextId++, ...entry });
+      if (this.lines.length > MAX_LINES) {
+        this.lines.splice(0, this.lines.length - MAX_LINES);
+      }
+      if (this.stickToBottom) {
+        this.$nextTick(this.scrollToBottom);
       }
     },
+
+    onScroll() {
+      const el = this.$refs.logBody;
+      if (!el) return;
+      this.stickToBottom = el.scrollHeight - el.scrollTop - el.clientHeight < STICK_THRESHOLD;
+    },
+
+    scrollToBottom() {
+      const el = this.$refs.logBody;
+      if (el) el.scrollTop = el.scrollHeight;
+    },
+
+    jumpToBottom() {
+      this.stickToBottom = true;
+      this.$nextTick(this.scrollToBottom);
+    },
+
+    formatTime(ts) {
+      if (!ts) return '';
+      const d = new Date(ts);
+      const p = (n, w = 2) => String(n).padStart(w, '0');
+      return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}`;
+    },
+
+    formatFull(ts) {
+      return ts ? new Date(ts).toLocaleString() : '';
+    },
+
+    priorityClass(priority) {
+      if (priority <= 3) return 'sev-error';
+      if (priority === 4) return 'sev-warn';
+      if (priority >= 7) return 'sev-debug';
+      return '';
+    },
+
+    disconnectStream() {
+      if (this.logSource) {
+        this.logSource.close();
+        this.logSource = null;
+      }
+    },
+
     closeViewer() {
-      this.stopPolling();
+      this.disconnectStream();
       this.$emit('close-viewer');
     },
-    scrollToBottom() {
-      const logContent = this.$refs.logContent;
-      logContent.scrollTop = logContent.scrollHeight;
-    }
   },
-  watch: {
-    logs() {
-      this.$nextTick(() => {
-        this.scrollToBottom();
-      });
-    }
-  }
-}
+};
 </script>
 
 <style scoped>
 .log-viewer-backdrop {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
   background-color: var(--ark-color-black);
   display: flex;
   justify-content: center;
@@ -88,38 +168,127 @@ export default {
 }
 
 .log-viewer-container {
+  position: relative;
   background-color: var(--ark-color-white);
-  padding: 30px;
+  padding: 20px;
   border-radius: 12px;
-  width: 600px;
-  max-width: 90%;
-  max-height: 80vh;
+  width: 80vw;
+  max-width: 1100px;
+  height: 80vh;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
   box-shadow: 0px 0px 20px var(--ark-color-black-shadow);
-  overflow-y: auto;
 }
 
-h2 {
-  text-align: center;
-  margin-bottom: 20px;
+.log-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.log-header h2 {
+  margin: 0;
   color: var(--ark-color-black);
 }
 
-.log-content {
-  background-color: var(--ark-color-black-shadow);
-  padding: 20px;
-  border-radius: 4px;
-  border: 1px solid var(--ark-color-black-shadow);
-  max-height: 60vh;
+.live-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--ark-color-orange);
+}
+
+.live-status.live {
+  color: var(--ark-color-green);
+}
+
+.live-status .dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background-color: currentColor;
+}
+
+.live-status.live .dot {
+  animation: pulse 1.6s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.log-body {
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
-  white-space: pre-wrap; /* Ensures that the text maintains line breaks */
-  font-family: monospace; /* Uses a monospaced font for log output */
-  color: var(--ark-color-black-bold);
+  background-color: #1e1e1e;
+  border-radius: 6px;
+  padding: 12px 14px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #d4d4d4;
+  text-align: left;
+}
+
+.log-row {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.log-ts {
+  flex: 0 0 auto;
+  color: #6a8caf;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.log-msg {
+  flex: 1 1 auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.sev-error { color: #f48771; }
+.sev-warn  { color: #e2c08d; }
+.sev-debug { color: #808080; }
+
+.log-empty,
+.log-error {
+  color: #9aa0a6;
+  font-style: italic;
+  padding: 8px 0;
+}
+
+.log-error {
+  color: #f48771;
+  font-style: normal;
+}
+
+.jump-button {
+  position: absolute;
+  right: 36px;
+  bottom: 84px;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 16px;
+  background-color: var(--ark-color-green);
+  color: var(--ark-color-white);
+  cursor: pointer;
+  font-size: 13px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
 }
 
 .actions {
   display: flex;
   justify-content: center;
-  margin-top: 20px;
+  margin-top: 16px;
 }
 
 .close-button {
@@ -130,7 +299,7 @@ h2 {
   font-size: 16px;
   font-weight: 600;
   background-color: var(--ark-color-red);
-  color: var(--ark-color-white);;
+  color: var(--ark-color-white);
   transition: background-color 0.3s ease;
 }
 

--- a/frontend/src/services/ServicesService.js
+++ b/frontend/src/services/ServicesService.js
@@ -7,7 +7,6 @@ const ENDPOINTS = {
   restart: (serviceName) => `/api/service/restart?serviceName=${serviceName}`,
   enable: (serviceName) => `/api/service/enable?serviceName=${serviceName}`,
   disable: (serviceName) => `/api/service/disable?serviceName=${serviceName}`,
-  logs: (serviceName) => `/api/service/logs?serviceName=${serviceName}`,
   config: (serviceName) => `/api/service/config?serviceName=${serviceName}`,
 };
 
@@ -29,9 +28,6 @@ export default {
   },
   async disableService(serviceName) {
     return axios.post(ENDPOINTS.disable(serviceName));
-  },
-  async getServiceLogs(serviceName) {
-    return axios.get(ENDPOINTS.logs(serviceName));
   },
   async getServiceConfig(serviceName) {
     return axios.get(ENDPOINTS.config(serviceName));

--- a/services/service-manager/service_manager.py
+++ b/services/service-manager/service_manager.py
@@ -20,8 +20,11 @@ import json
 import subprocess
 import re
 import logging
+import asyncio
+from collections.abc import AsyncIterator
 
 from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 import uvicorn
 
@@ -61,11 +64,11 @@ class ActionResponse(BaseModel):
     message: str | None = None
 
 
-class LogsResponse(BaseModel):
-    status: str
-    service: str
-    logs: str | None = None
-    message: str | None = None
+class LogLine(BaseModel):
+    """One journal entry pushed over the /logs/stream SSE channel."""
+    ts: int | None = None  # epoch milliseconds (None if journald omitted it)
+    priority: int = 6      # syslog severity 0..7; 6 = info, <=3 = error
+    message: str
 
 
 class ConfigResponse(BaseModel):
@@ -90,6 +93,45 @@ _ANSI_ESCAPE = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 
 def strip_ansi(text: str) -> str:
     return _ANSI_ESCAPE.sub('', text)
+
+
+def parse_journal_line(raw: bytes) -> LogLine | None:
+    """Turn one `journalctl -o json` line into a LogLine, or None if unusable.
+
+    journald gives __REALTIME_TIMESTAMP as microseconds-since-epoch (a string),
+    MESSAGE as a string or — for non-UTF-8 payloads — an array of byte values,
+    and PRIORITY as a syslog level 0..7.
+    """
+    try:
+        obj = json.loads(raw)
+    except ValueError:
+        return None
+
+    if not isinstance(obj, dict):
+        return None
+
+    message = obj.get("MESSAGE")
+    if isinstance(message, list):
+        # journald encodes a non-UTF-8 message as an array of byte values.
+        try:
+            message = bytes(message).decode("utf-8", "replace")
+        except (ValueError, TypeError):
+            message = ""
+    elif not isinstance(message, str):
+        message = "" if message is None else str(message)
+
+    ts: int | None
+    try:
+        ts = int(obj["__REALTIME_TIMESTAMP"]) // 1000
+    except (KeyError, ValueError, TypeError):
+        ts = None
+
+    try:
+        priority = int(obj.get("PRIORITY", 6))
+    except (ValueError, TypeError):
+        priority = 6
+
+    return LogLine(ts=ts, priority=priority, message=strip_ansi(message))
 
 
 class ServiceManager:
@@ -301,26 +343,6 @@ class ServiceManager:
             return ActionResponse(status="fail", service=service_name, message=message)
 
     @staticmethod
-    def get_logs(service_name: str, num_lines: int = 50) -> LogsResponse:
-        if not ServiceManager.is_known_service(service_name):
-            return LogsResponse(status="fail", service=service_name,
-                                message=f"Unknown or unmanaged service: {service_name}")
-
-        try:
-            process = subprocess.run(
-                ["journalctl", "-u", service_name, "-n", str(num_lines), "--no-pager", "-o", "cat"],
-                capture_output=True,
-                text=True,
-                timeout=10
-            )
-
-            logs = strip_ansi(process.stdout).strip()
-
-            return LogsResponse(status="success", service=service_name, logs=logs)
-        except Exception as e:
-            return LogsResponse(status="fail", service=service_name, message=str(e))
-
-    @staticmethod
     def get_config(service_name: str) -> ConfigResponse:
         if not ServiceManager.is_known_service(service_name):
             return ConfigResponse(status="fail", data=f"Unknown or unmanaged service: {service_name}")
@@ -399,10 +421,71 @@ def disable_service(serviceName: str) -> ActionResponse:
     return ServiceManager.disable_service(serviceName)
 
 
-@app.get("/logs", response_model_exclude_none=True)
-def get_service_logs(serviceName: str) -> LogsResponse:
-    logger.debug(f"GET /logs called for {serviceName}")
-    return ServiceManager.get_logs(serviceName)
+@app.get("/logs/stream")
+async def stream_service_logs(serviceName: str) -> StreamingResponse:
+    """Server-Sent Events stream of a service's journal, tailing live.
+
+    Runs `journalctl -u <svc> -n 200 -f -o json` and pushes each entry as a
+    `log_line` event (a LogLine: {ts, priority, message}). One-way server->client
+    push, so it rides the same /api HTTP proxy chain as the REST endpoints — no
+    websocket layer. The client appends each line and renders a timestamp column
+    plus a severity colour, so there is no polling and no wholesale re-render.
+    """
+    headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+
+    # Guard the user-supplied unit name before it reaches journalctl (same gate
+    # as every other systemctl/journalctl call). Can't return a 422 body the way
+    # the REST routes do once we're a stream, so emit one error event and close.
+    if not ServiceManager.is_known_service(serviceName):
+        async def reject() -> AsyncIterator[str]:
+            payload = json.dumps({"message": f"Unknown or unmanaged service: {serviceName}"})
+            yield f"event: log_error\ndata: {payload}\n\n"
+
+        return StreamingResponse(reject(), media_type="text/event-stream", headers=headers)
+
+    async def event_stream() -> AsyncIterator[str]:
+        logger.debug(f"Log stream connected for {serviceName}")
+        # -n 200 seeds recent history so the pane isn't empty on open; -f follows;
+        # -o json is structured so the client gets timestamp + severity, not just
+        # text. limit= raises the line buffer so a long entry can't overrun it.
+        proc = await asyncio.create_subprocess_exec(
+            "journalctl", "-u", serviceName, "-n", "200", "-f", "-o", "json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+            limit=2 ** 20,
+        )
+
+        try:
+            assert proc.stdout is not None
+            while True:
+                try:
+                    raw = await asyncio.wait_for(proc.stdout.readline(), timeout=30.0)
+                except asyncio.TimeoutError:
+                    # A quiet service writes nothing; a comment keeps the stream
+                    # (and any intermediate proxy) from timing out the connection.
+                    yield ": keepalive\n\n"
+                    continue
+
+                if not raw:
+                    break  # journalctl exited
+
+                line = parse_journal_line(raw)
+                if line is None:
+                    continue
+
+                yield f"event: log_line\ndata: {json.dumps(line.model_dump())}\n\n"
+        finally:
+            # Runs on client disconnect (the generator is closed) as well as on a
+            # normal exit, so the followed journalctl is never left orphaned.
+            logger.debug(f"Log stream disconnected for {serviceName}")
+            if proc.returncode is None:
+                proc.terminate()
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    proc.kill()
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream", headers=headers)
 
 
 @app.get("/config")


### PR DESCRIPTION
## Summary
Replace the polled service-log view with a live tail over Server-Sent Events, and remove the now-unused polling endpoint.

## Problem
The log viewer polled `GET /api/service/logs` once a second and rendered the last 50 lines via `journalctl -o cat` — no timestamps, so a quiet service's output was indistinguishable from a stalled view, and the whole blob was replaced each tick (no real append, and it yanked you back to the bottom while scrolling up to read).

## Solution
Add `GET /logs/stream` in service-manager — `journalctl -u <svc> -n 200 -f -o json` pushed as `log_line` SSE events (`{ts, priority, message}`), with a keepalive and graceful teardown of the followed process on disconnect — reusing the existing `/stats/stream` SSE pattern, so no gateway or nginx changes. `LogViewer.vue` now consumes it with `EventSource`: left timestamp column, severity colours, smart auto-scroll, a wider dark pane, and live/reconnecting/error states. The old `/logs` route, `ServiceManager.get_logs`, the `LogsResponse` model, and the frontend `getServiceLogs` helper have no remaining callers and are removed.
