### PR TITLE
feat(jetson): emit parseable OK/FAILED result lines from camera and fan checks

### DIFF
--- a/platform/jetson/scripts/check_cameras.sh
+++ b/platform/jetson/scripts/check_cameras.sh
@@ -4,24 +4,23 @@
 # Logic lifted from the jetson_test.sh check_cameras() function.
 # Usage: ./check_cameras.sh [num_cameras]   (default 4)
 # Returns: 0 if every camera streams, 1 if any camera fails.
+# Per camera prints one parseable line: "/dev/videoN: OK - <fps>" or "/dev/videoN: FAILED: <reason>".
 
 TOTAL_CAMERAS="${1:-4}"  # number of CSI cameras to test
 STREAM_COUNT=25          # frames to capture per camera
 
 status=0
 for ((i = 0; i < TOTAL_CAMERAS; i++)); do
-    echo "Testing /dev/video$i:"
-    # Capture frames to /dev/null and analyze what v4l2-ctl reports.
+    # Capture frames to /dev/null and parse what v4l2-ctl reports for this device.
     output=$(v4l2-ctl --device=/dev/video$i --stream-mmap --stream-count=$STREAM_COUNT --stream-to=/dev/null 2>&1)
 
-    if [[ $output == *'VIDIOC_STREAMON returned -1'* ]]; then
-        echo "Camera /dev/video$i: ERROR detected."
-        echo "$output" | grep -i error  # surface the error lines
+    if [ ! -e "/dev/video$i" ] || [[ $output == *'Cannot open device'* ]] || [[ $output == *'No such file'* ]]; then
+        echo "/dev/video$i: FAILED: not found"
         status=1
     elif [[ $output == *'fps'* ]]; then
-        echo "Camera /dev/video$i: SUCCESS - $(echo "$output" | grep -o '[0-9]*\.[0-9]* fps')"
+        echo "/dev/video$i: OK - $(echo "$output" | grep -o '[0-9]*\.[0-9]* fps' | head -1)"
     else
-        echo "Camera /dev/video$i: FAILED to confirm status."
+        echo "/dev/video$i: FAILED: no frames"
         status=1
     fi
 done

--- a/platform/jetson/scripts/check_fan.sh
+++ b/platform/jetson/scripts/check_fan.sh
@@ -60,6 +60,7 @@ check_fan() {
                             echo "Fan set to 100% PWM (255)"
                         else
                             echo "Failed to set fan to 100% - insufficient privileges"
+                            FAIL_REASON="cannot set pwm (privileges)"
                             fan_status=1
                             return $fan_status
                         fi
@@ -71,6 +72,7 @@ check_fan() {
                             # Critical check: RPM must be > 0 for fan to be considered working
                             if [ "$rpm_value" -eq 0 ]; then
                                 echo "CRITICAL FAILURE: Fan RPM is 0 at 100% speed - Fan may be unplugged or broken!"
+                                FAIL_REASON="rpm 0 at full speed"
                                 fan_status=1
                                 return $fan_status
                             elif [ "$rpm_value" -lt 500 ]; then
@@ -78,11 +80,13 @@ check_fan() {
                             fi
                         else
                             echo "FAILURE: Cannot read RPM sensor"
+                            FAIL_REASON="cannot read rpm sensor"
                             fan_status=1
                             return $fan_status
                         fi
                     else
                         echo "FAILURE: RPM sensor not found"
+                        FAIL_REASON="no rpm sensor"
                         fan_status=1
                         return $fan_status
                     fi
@@ -119,6 +123,7 @@ check_fan() {
                                     # Critical check: RPM must always be > 0 during operation
                                     if [ "$current_rpm" -eq 0 ]; then
                                         echo "✗ CRITICAL FAILURE: RPM dropped to 0 - Fan disconnected or failed!"
+                                        FAIL_REASON="rpm dropped to 0 during ramp"
                                         fan_status=1
                                         break
                                     fi
@@ -174,6 +179,7 @@ check_fan() {
                                     # Critical check: RPM must always be > 0 during operation
                                     if [ "$current_rpm" -eq 0 ]; then
                                         echo "✗ CRITICAL FAILURE: RPM dropped to 0 - Fan disconnected or failed!"
+                                        FAIL_REASON="rpm dropped to 0 during ramp"
                                         fan_status=1
                                         break
                                     fi
@@ -200,6 +206,7 @@ check_fan() {
                                         echo "Maximum speed test WARNING - Fan RPM is $current_rpm (may be thermally limited)"
                                     else
                                         echo "Maximum speed test FAILED - Fan RPM is 0, fan disconnected!"
+                                        FAIL_REASON="rpm 0 at full speed"
                                         fan_status=1
                                     fi
                                 fi
@@ -239,24 +246,34 @@ check_fan() {
                     fi
                 else
                     echo "Fan check FAILED - Invalid PWM value: $pwm_value"
+                    FAIL_REASON="invalid pwm value"
                     fan_status=1
                 fi
             else
                 echo "Fan check FAILED - PWM control file not found"
+                FAIL_REASON="no pwm1 control"
                 fan_status=1
             fi
         else
             echo "Fan check FAILED - hwmon directory not found"
+            FAIL_REASON="no hwmon device"
             fan_status=1
         fi
     else
         echo "Fan check FAILED - PWM fan device not found"
+        FAIL_REASON="no pwm-fan device"
         fan_status=1
     fi
     
     return $fan_status
 }
 
-# Run the fan check
+# Run the fan check and emit a single parseable result line for the bench test to read.
 check_fan
-exit $?
+result=$?
+if [ "$result" -eq 0 ]; then
+    echo "fan: OK"
+else
+    echo "fan: FAILED: ${FAIL_REASON:-check failed}"
+fi
+exit $result


### PR DESCRIPTION
## Summary
The Jetson camera and fan check scripts now print one machine-readable result line per device, so the manufacturing bench test can surface the specific failure cause rather than a bare pass/fail.

## Problem
The scripts emitted free-form, inconsistent output: `check_cameras.sh` printed `Camera /dev/videoN: SUCCESS` / `FAILED to confirm status`, and `check_fan.sh` buried its outcome in pages of ramp diagnostics. A caller could read the exit code but not *why* a check failed, so every failure collapsed to a generic boolean.

## Solution
`check_cameras.sh` prints one parseable line per device — `/dev/videoN: OK - <fps>` or `/dev/videoN: FAILED: <reason>` (`not found` / `no frames`). `check_fan.sh` ends with a single `fan: OK` or `fan: FAILED: <reason>` line, the reason set at each failure point (e.g. `rpm 0 at full speed`, `no pwm-fan device`). Exit codes are unchanged.