### PR TITLE
fix(frontend): scope full-width layout to the Video route

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app">
+  <div id="app" :class="{ 'fill-viewport': isActive('/video-page') }">
     <div class="sidebar" ref="sidebar">
       <img src="@/assets/logo.png" alt="Logo" class="logo">
       <router-link class="link" :class="{ active: isActive('/') }" to="/">System</router-link>
@@ -94,14 +94,19 @@ html, body {
 
 #app {
   display: flex;
-  /* Pin to the viewport width. Without this the flex container shrink-wraps to its
-     content, which collapses any page whose content has no intrinsic width — the Video
-     page (the video is position:absolute, so the frame's only in-flow sibling is the
-     short "Video" title) renders as a thin strip the width of that title. */
-  width: 100%;
   font-family: 'Roboto', sans-serif;
   color: var(--ark-color-black); /* Should be your black color */
   background-color: var(--ark-color-white); /* Your specified white color */
+}
+
+/* The app root is a shrink-wrapping flex item, so each page sizes #app to its own
+   content — data pages keep their natural width and stay left-aligned beside the sidebar.
+   The Video page has no intrinsic width (the video is position:absolute, leaving only the
+   short "Video" title in flow), so it would collapse to a thin strip. Pin #app to the
+   viewport on the Video route only, so the frame fills the area without also stretching
+   and centering the data pages in a full-width column. */
+#app.fill-viewport {
+  width: 100%;
 }
 
 .sidebar {

--- a/frontend/src/pages/AutopilotPage.vue
+++ b/frontend/src/pages/AutopilotPage.vue
@@ -680,6 +680,7 @@ export default {
   align-items: center;
   width: 100%;
   max-width: 1200px;
+  min-width: 800px;
   margin: 0 auto;
   padding: 20px;
   gap: 20px;

--- a/frontend/src/pages/ConnectionsPage.vue
+++ b/frontend/src/pages/ConnectionsPage.vue
@@ -1333,6 +1333,7 @@ export default {
   align-items: center;
   width: 100%;
   max-width: 1200px;
+  min-width: 800px;
   margin: 0 auto;
   padding: 20px;
   gap: 20px;


### PR DESCRIPTION
## Summary
Restore the original layout of every data page (System, Autopilot, Connections, Services) while keeping the Video page full-width fix from 962f4f8.

## Problem
962f4f8 fixed the Video page — which collapsed to a thin strip — by setting `width: 100%` on `#app`. Because `#app` is mounted inside the `index.html` `#app` container it is a shrink-wrapping flex item, so pinning it to `100%` forced the full viewport width on *every* route. Each data page's `margin: 0 auto` then centered its width-capped content in a full-width column instead of sitting at its natural width beside the sidebar.

## Solution
Scope the `width: 100%` to the Video route only, via a `fill-viewport` class toggled by the active route, and restore the `min-width: 800px` the commit dropped from the Autopilot and Connections containers. Non-Video routes go back to shrink-wrapping `#app` to their own content, so they render as they did before the commit — the Autopilot and Connections files are byte-identical to their pre-commit state, and System/Services were never width-constrained by `#app`. On the Video route `#app` still resolves to `display: flex; width: 100%`, so the frame keeps the full-width fix.
