### PR TITLE
fix(frontend): left-align the Video page like the other pages

### DIFF
--- a/frontend/src/pages/VideoPage.vue
+++ b/frontend/src/pages/VideoPage.vue
@@ -246,7 +246,10 @@ export default {
   width: 100%;
   max-width: 1600px;
   height: 100vh;
-  margin: 0 auto;
+  /* Left-aligned (not centered): the Video route widens #app to the full viewport, so
+     keep the frame beside the sidebar like the other pages instead of floating it in the
+     middle of that full width. */
+  margin: 0;
   padding: 16px 20px 20px;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
Left-align the Video page so it sits beside the sidebar like the other pages, instead of floating centered in the middle of the screen.

## Problem
The Video route widens `#app` to the full viewport (so the live frame isn't a thin strip — see #96). The Video page's `.page-container` still used `margin: 0 auto`, which centered its capped (max-width 1600px) content in that full width, leaving a large gap on the left between it and the sidebar. The data pages don't show this because `#app` shrink-wraps to their content on their routes.

## Solution
Drop the auto side-margins on the Video page's `.page-container` so it left-aligns at the content area's left edge, matching the data pages. Width, max-width, and the centered title are unchanged.
