### PR TITLE
fix(autopilot-manager): refresh the autopilot version after a reflash

### DIFF
--- a/services/autopilot-manager/autopilot_manager.py
+++ b/services/autopilot-manager/autopilot_manager.py
@@ -259,6 +259,16 @@ class MAVLinkConnection:
         time_since_heartbeat = (datetime.now() - self.last_heartbeat).total_seconds()
         return time_since_heartbeat < self.heartbeat_timeout
 
+    def invalidate_version(self):
+        """Drop the cached version/git hash so the message loop re-requests them.
+
+        PX4 only sends AUTOPILOT_VERSION when asked, and the loop asks only while
+        the version is "Unknown". Anything that can leave the FC running different
+        firmware must clear the latch or the stale string is reported forever."""
+        with self._lock:
+            self.autopilot_data["version"] = "Unknown"
+            self.autopilot_data["git_hash"] = "Unknown"
+
     def request_autopilot_version(self):
         """Request the autopilot version information"""
         if not self.mav_connection:
@@ -435,6 +445,9 @@ class MAVLinkConnection:
                     if not disconnect_logged:
                         logger.warning("No autopilot heartbeat; probing and reconnecting in the background")
                         disconnect_logged = True
+                        # The FC may return reflashed or rebooted, so the cached
+                        # version is unverified until it answers again.
+                        self.invalidate_version()
 
                     # Probe with a GCS heartbeat at ~1 Hz to elicit a response.
                     if current_time - last_probe_time >= 1.0:
@@ -659,6 +672,9 @@ class AutopilotManager:
             # Disconnect from MAVLink first to avoid conflicts
             logger.debug("Disconnecting MAVLink connection")
             self.mavlink.disconnect()
+            # disconnect() stops the message loop, so the heartbeat-gap path that
+            # normally invalidates the version cannot run during a flash.
+            self.mavlink.invalidate_version()
 
             # Stop mavlink router service if it's running
             logger.debug("Checking if mavlink-router is active")


### PR DESCRIPTION
## Summary

The autopilot version in the UI's System Information latched on first read and never updated after flashing new firmware, until QGC was opened.

## Problem

The message loop requests AUTOPILOT_VERSION only while the cached version still reads `"Unknown"`, and nothing ever reset it back — it was assigned only in `__init__`. Once a real version landed, the request was never issued again, and PX4 does not send AUTOPILOT_VERSION unsolicited. `flash_firmware` tears the link down and rebuilds it on the same `MAVLinkConnection`, so the cache survived a flash untouched.

Opening QGC masked the bug: QGC requests AUTOPILOT_VERSION itself, and since that message carries no target fields, mavlink-router fans the reply out to every endpoint including autopilot_manager on 14571, where the handler takes it unconditionally.

## Solution

Clear the cached version and git hash so the existing 5-second poll re-arms, at both points where the FC may come back running different firmware: the heartbeat-gap episode, and the flash. The flash needs its own call rather than relying on the gap — `disconnect()` stops the message loop, so that branch cannot run during a flash. The invalidation sits after the flash guard clauses, so a missing firmware file or absent FC does not discard a valid version.

Verified by driving the real message loop against a fake FC that answers version requests: the version now refreshes from 1.14.3 to 1.15.0 across a simulated reflash with no QGC involved.