### PR TITLE
feat(pointperfect): add AssistNow (MGA) start-up assistance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This service provides an RTSP server via gstreamer. The stream from the first co
 This service receives RTCM corrections from the PointOne GNSS Corrections service and publishes them to the flight controller via MAVLink.
 
 **pointperfect.service** <br>
-This service receives GNSS corrections from the u-blox PointPerfect NTRIP service (RTCM by default, optional SPARTN) and publishes them to the flight controller via MAVLink.
+This service receives GNSS corrections from the u-blox PointPerfect NTRIP service (RTCM by default, optional SPARTN) and publishes them to the flight controller via MAVLink. For u-blox receivers it can optionally request AssistNow (MGA) start-up assistance for a faster time to first fix (`use_mga`).
 
 **ark-ui-backend.service** <br>
 This service provides an API gateway for the ARK UI.

--- a/packaging/config/pointperfect.toml
+++ b/packaging/config/pointperfect.toml
@@ -14,9 +14,15 @@ ntrip_port = 2102          # 2102 = TLS, 2101 = plain TCP
 correction_format = "rtcm"
 correction_format_options = ["rtcm", "spartn"]
 
-# Mountpoint. Leave empty to derive it from correction_format
-# (NEAR-RTCM or NEAR-SPARTN); set it explicitly to override.
+# Mountpoint. Leave empty to derive it from correction_format and use_mga
+# (NEAR-RTCM[-MGA] or NEAR-SPARTN[-MGA]); set it explicitly to override.
 ntrip_mountpoint = ""
+
+# Request AssistNow (MGA) start-up assistance for a faster time to first fix.
+# The *-MGA mountpoints send u-blox ephemeris (UBX-MGA) once on connect, ahead
+# of the correction stream; the client forwards it to the receiver. u-blox
+# receivers only, and requires send_gga (corrections start after a valid GGA).
+use_mga = false
 
 ntrip_username = "your_username_goes_here"
 ntrip_password = "your_password_goes_here"


### PR DESCRIPTION
## Summary
Bumps the pointperfect client to [pointperfect-client-mavlink#2](https://github.com/ARK-Electronics/pointperfect-client-mavlink/pull/2) and exposes its new `use_mga` option in the packaged config: PointPerfect's `NEAR-RTCM-MGA` / `NEAR-SPARTN-MGA` mountpoints deliver u-blox AssistNow ephemeris (UBX-MGA) once on connect, ahead of the corrections, for a faster time to first fix. Requested by our u-blox rep.

## Problem
The client only used the plain `NEAR-RTCM` / `NEAR-SPARTN` mountpoints; there was no way to opt into the assistance-data feed, and the client's forwarding path could not have delivered the connect-time MGA burst to the receiver intact (details in the client PR).

## Solution
Submodule bump plus `use_mga = false` (opt-in, u-blox receivers only) in `packaging/config/pointperfect.toml`, which the ARK UI picks up as a toggle like the other booleans. Merge after the client PR; re-bump the pointer if that PR gains review commits.