### PR TITLE
feat(install): allow downgrading the ARK-OS deb

### DIFF
--- a/packaging/install_ark_os.sh
+++ b/packaging/install_ark_os.sh
@@ -16,8 +16,8 @@
 # /usr/lib/ark-os/mavsdk (issue #74), independent of any system MAVSDK.
 #
 # Re-running is safe: jetson-stats is skipped when already at the pinned version,
-# and re-installing the ark-os deb upgrades it in place — so this is also the
-# supported way to update a live device.
+# and re-installing the ark-os deb upgrades (or downgrades) it in place — so this
+# is also the supported way to update a live device.
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
@@ -138,8 +138,9 @@ fetch() {
 
 # apt-get treats a bare filename as a package name; only a path containing a
 # slash is read as a local deb. Resolve to an absolute path so cwd-relative and
-# downloaded debs both install correctly.
-apt_install_deb() { apt-get install -y "$(readlink -f "$1")"; }
+# downloaded debs both install correctly. --allow-downgrades lets an older build
+# install over a newer one (version testing/rollback), which apt refuses by default.
+apt_install_deb() { apt-get install -y --allow-downgrades "$(readlink -f "$1")"; }
 
 install_jtop() {
     apt-get install -y python3-pip || return 1


### PR DESCRIPTION
## Summary
fixes #105

Pass `--allow-downgrades` when installing the ARK-OS deb so an older build can replace a newer one.

## Problem
`apt-get install` refuses downgrades by default, so switching a device between ARK-OS versions during testing required manual package handling.

## Solution
Add `--allow-downgrades` to the `apt_install_deb` helper. Upgrades and same-version reinstalls are unaffected.