### PR TITLE
ci(build-deb): re-enable the pi bookworm and trixie legs

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -29,16 +29,16 @@ jobs:
             runner: ubuntu-22.04-arm
             container: ""
             extra_deps: "libbluetooth-dev"
-          # - platform: pi
-          #   codename: bookworm
-          #   runner: ubuntu-22.04-arm
-          #   container: "debian:bookworm"
-          #   extra_deps: ""
-          # - platform: pi
-          #   codename: trixie
-          #   runner: ubuntu-22.04-arm
-          #   container: "debian:trixie"
-          #   extra_deps: ""
+          - platform: pi
+            codename: bookworm
+            runner: ubuntu-22.04-arm
+            container: "debian:bookworm"
+            extra_deps: ""
+          - platform: pi
+            codename: trixie
+            runner: ubuntu-22.04-arm
+            container: "debian:trixie"
+            extra_deps: ""
     # Build each platform on a host whose OS matches the target so the bundled venv
     # and natively-compiled binaries are ABI-compatible. The venv is created with
     # `python3 -m venv --copies`, which ships the interpreter but resolves the stdlib


### PR DESCRIPTION
## Summary

Restores the two Raspberry Pi build legs to the deb matrix so releases publish `ark-os-pi-bookworm` and `ark-os-pi-trixie` alongside `ark-os-jetson-jammy` again.

## Problem

The pi legs were commented out in f88b10a while iterating on jetson. Every release since v1.0.14 has shipped the jetson-jammy deb only, so Pi users have had no published package for the last four releases even though both codenames are still live entries in `packaging/build.sh`'s `BASELINES` table.

## Solution

Uncomment the matrix entries — an exact revert of the disable. The PR build exercises both legs before the next tag, which matters because `debian:trixie` has promoted to stable since these last ran.