### PR TITLE
feat(logs-page): add a Logs page for browsing and fetching vehicle logs

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,6 +7,7 @@
       <router-link class="link" :class="{ active: isActive('/connections-page') }" to="/connections-page">Connections</router-link>
       <router-link class="link" :class="{ active: isActive('/services-page') }" to="/services-page">Services</router-link>
       <router-link class="link" :class="{ active: isActive('/video-page') }" to="/video-page">Video</router-link>
+      <router-link class="link" :class="{ active: isActive('/logs-page') }" to="/logs-page">Logs</router-link>
       <a
         class="link external-link"
         :href="`http://${hostname}.local/flight-review`"

--- a/frontend/src/pages/LogsPage.vue
+++ b/frontend/src/pages/LogsPage.vue
@@ -1,0 +1,709 @@
+<template>
+  <div class="page-container">
+    <h1 class="page-title">Logs</h1>
+
+    <div v-if="loading" class="loading-container">
+      <i class="fas fa-spinner fa-spin"></i>
+      <p>Loading logs...</p>
+    </div>
+
+    <div v-else-if="error" class="error-container">
+      <i class="fas fa-exclamation-triangle"></i>
+      <h2>Unable to Load Logs</h2>
+      <p>{{ error }}</p>
+      <button @click="retry" class="retry-button">
+        <i class="fas fa-refresh"></i> Retry
+      </button>
+    </div>
+
+    <div v-else class="logs-content">
+      <div class="section-container">
+        <div class="status-bar">
+          <span class="status-item">
+            <span class="dot" :class="status.connected ? 'dot-ok' : 'dot-bad'"></span>
+            {{ status.connected ? 'Vehicle connected' : 'Waiting for the vehicle' }}
+          </span>
+          <span class="status-item" v-if="status.connected">
+            <span class="dot" :class="status.ftp_available ? 'dot-ok' : 'dot-bad'"></span>
+            {{ status.ftp_available ? `MAVLink FTP: ${status.log_root}` : 'MAVLink FTP unavailable' }}
+          </span>
+          <span class="status-item warning" v-if="status.armed">
+            <i class="fas fa-exclamation-triangle"></i> Armed — transfers are paused
+          </span>
+          <span class="status-item counts">
+            {{ logs.length }} logs · {{ downloadedCount }} downloaded · {{ uploadedCount }} uploaded
+          </span>
+        </div>
+      </div>
+
+      <div class="section-container">
+        <div class="section-header">
+          <h2 class="section-title">
+            {{ selected.length ? `${selected.length} selected` : 'Select logs to download or upload' }}
+          </h2>
+          <div class="actions-bar">
+            <button class="action-button primary" :disabled="!selected.length || busy"
+              @click="downloadSelected">
+              <i class="fas fa-download"></i> Download &amp; Upload
+            </button>
+            <button class="action-button" :disabled="!selected.length || busy" @click="downloadOnly">
+              <i class="fas fa-hdd"></i> Download Only
+            </button>
+            <button class="action-button" :disabled="!uploadableSelected.length || busy"
+              @click="uploadSelected">
+              <i class="fas fa-cloud-upload-alt"></i> Upload
+            </button>
+            <button class="action-button danger" :disabled="!cancellableSelected.length || busy"
+              @click="cancelSelected">
+              <i class="fas fa-times"></i> Cancel
+            </button>
+          </div>
+        </div>
+
+        <p v-if="message" class="message">{{ message }}</p>
+
+        <div class="table-container">
+          <table class="logs-table">
+            <thead>
+              <tr>
+                <th class="checkbox-cell">
+                  <input type="checkbox" :checked="allSelected" :indeterminate.prop="someSelected"
+                    @change="toggleAll" title="Select all">
+                </th>
+                <th>Date (local)</th>
+                <th>Name</th>
+                <th>Size</th>
+                <th>On Vehicle</th>
+                <th>Downloaded</th>
+                <th v-for="target in targets" :key="target">{{ targetLabel(target) }}</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="log in logs" :key="log.id" :class="{ 'active-row': log.id === status.downloading_id }">
+                <td class="checkbox-cell">
+                  <input type="checkbox" :value="log.id" v-model="selected">
+                </td>
+                <td class="nowrap">{{ formatDate(log.date) }}</td>
+                <td class="name-cell" :title="log.path">{{ log.name }}</td>
+                <td class="nowrap">{{ formatSize(log.size_bytes) }}</td>
+                <td>
+                  <i v-if="log.present" class="fas fa-check state-ok" title="Still on the vehicle"></i>
+                  <i v-else class="fas fa-minus state-muted" title="No longer on the vehicle"></i>
+                </td>
+                <td>
+                  <div v-if="log.id === status.downloading_id" class="progress">
+                    <div class="progress-fill" :style="{ width: downloadPercent + '%' }"></div>
+                    <span class="progress-text">{{ downloadPercent }}%</span>
+                  </div>
+                  <i v-else-if="log.downloaded" class="fas fa-check state-ok" title="Downloaded"></i>
+                  <i v-else-if="log.download_requested" class="fas fa-clock state-pending" title="Queued"></i>
+                  <i v-else class="fas fa-minus state-muted"></i>
+                </td>
+                <td v-for="target in targets" :key="target">
+                  <a v-if="uploadOf(log, target).uploaded && uploadOf(log, target).location"
+                    :href="plotUrl(target, uploadOf(log, target).location)" target="_blank"
+                    rel="noopener noreferrer" class="plot-link" title="Open in Flight Review">
+                    <i class="fas fa-external-link-alt"></i> View
+                  </a>
+                  <i v-else-if="uploadOf(log, target).uploaded" class="fas fa-check state-ok"></i>
+                  <i v-else-if="log.id === status.uploading_id && status.uploading_target === target"
+                    class="fas fa-spinner fa-spin state-pending" title="Uploading"></i>
+                  <i v-else-if="uploadOf(log, target).rejected" class="fas fa-ban state-bad"
+                    :title="uploadOf(log, target).message"></i>
+                  <i v-else-if="uploadOf(log, target).requested" class="fas fa-clock state-pending"
+                    title="Queued"></i>
+                  <i v-else class="fas fa-minus state-muted"></i>
+                </td>
+                <td>
+                  <div class="actions">
+                    <button v-if="log.downloaded" class="icon-button danger"
+                      title="Delete the downloaded copy" @click="deleteFile(log)">
+                      <i class="fas fa-trash"></i>
+                    </button>
+                    <span v-if="log.last_error" class="row-error" :title="log.last_error">
+                      <i class="fas fa-exclamation-triangle"></i>
+                    </span>
+                  </div>
+                </td>
+              </tr>
+              <tr v-if="logs.length === 0">
+                <td :colspan="7 + targets.length" class="empty-state">
+                  <div class="empty-message">
+                    <i class="fas fa-book"></i>
+                    <p>{{ status.connected ? 'No logs on the vehicle yet' : 'Waiting for the vehicle' }}</p>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import LogsService from '@/services/LogsService';
+
+// logloader only ever reports the path Flight Review redirected to. The origin
+// is added here so the link works from whatever host the browser is on, which
+// is not the 127.0.0.1 logloader itself uploaded to.
+const LOCAL_FLIGHT_REVIEW_PREFIX = '/flight-review';
+
+export default {
+  name: 'LogsPage',
+  data() {
+    return {
+      logs: [],
+      targets: [],
+      status: {},
+      selected: [],
+      loading: true,
+      error: null,
+      busy: false,
+      message: '',
+      eventSource: null,
+    };
+  },
+  computed: {
+    downloadedCount() {
+      return this.logs.filter((log) => log.downloaded).length;
+    },
+    uploadedCount() {
+      return this.logs.filter((log) => this.targets.some((t) => this.uploadOf(log, t).uploaded)).length;
+    },
+    allSelected() {
+      return this.logs.length > 0 && this.selected.length === this.logs.length;
+    },
+    someSelected() {
+      return this.selected.length > 0 && this.selected.length < this.logs.length;
+    },
+    selectedLogs() {
+      return this.logs.filter((log) => this.selected.includes(log.id));
+    },
+    // Uploading needs the file, so a log that is neither downloaded nor still on
+    // the vehicle cannot be uploaded at all.
+    uploadableSelected() {
+      return this.selectedLogs.filter(
+        (log) => (log.downloaded || log.present)
+          && this.targets.some((t) => !this.uploadOf(log, t).uploaded)
+      );
+    },
+    cancellableSelected() {
+      return this.selectedLogs.filter(
+        (log) => log.download_requested || this.targets.some((t) => this.uploadOf(log, t).requested)
+      );
+    },
+    downloadPercent() {
+      const total = this.status.download_total_bytes;
+      if (!total) return 0;
+      return Math.round((100 * this.status.downloaded_bytes) / total);
+    },
+  },
+  mounted() {
+    this.fetchLogs();
+    this.connectStream();
+  },
+  beforeUnmount() {
+    this.disconnectStream();
+  },
+  methods: {
+    async fetchLogs() {
+      try {
+        const response = await LogsService.getLogs();
+        this.applyPayload(response.data);
+        this.loading = false;
+        this.error = null;
+      } catch (error) {
+        this.loading = false;
+        this.error = error.response?.data?.error
+          || error.message
+          || 'Failed to reach logloader. Is the service running?';
+      }
+    },
+
+    applyPayload(payload) {
+      this.logs = payload.logs || [];
+      this.targets = payload.targets || [];
+      this.status = payload.status || {};
+
+      // Drop selections for logs that are gone, so an action cannot be sent for
+      // an id the backend no longer knows.
+      const known = new Set(this.logs.map((log) => log.id));
+      this.selected = this.selected.filter((id) => known.has(id));
+    },
+
+    connectStream() {
+      this.disconnectStream();
+
+      const source = new EventSource(LogsService.eventsUrl());
+      this.eventSource = source;
+
+      // The full list only arrives when it changed. Transfer progress ticks
+      // several times a second and comes through as `status` alone.
+      source.addEventListener('logs', (event) => {
+        const payload = this.parseEvent(event);
+        if (!payload) return;
+        this.applyPayload(payload);
+        this.loading = false;
+        this.error = null;
+      });
+
+      source.addEventListener('status', (event) => {
+        const status = this.parseEvent(event);
+        if (status) this.status = status;
+      });
+
+      source.onerror = () => {
+        // Connection-level only; EventSource reconnects on its own.
+      };
+    },
+
+    parseEvent(event) {
+      try {
+        return JSON.parse(event.data);
+      } catch {
+        return null;
+      }
+    },
+
+    disconnectStream() {
+      if (this.eventSource) {
+        this.eventSource.close();
+        this.eventSource = null;
+      }
+    },
+
+    async run(action, describe) {
+      this.busy = true;
+      this.message = '';
+      try {
+        const response = await action();
+        this.message = describe(response.data);
+      } catch (error) {
+        this.message = error.response?.data?.error || error.message || 'Request failed';
+      } finally {
+        this.busy = false;
+      }
+    },
+
+    downloadSelected() {
+      this.run(
+        () => LogsService.requestDownload(this.selected, true),
+        (data) => `Queued ${data.queued} log(s) for download and upload`
+      );
+    },
+
+    downloadOnly() {
+      this.run(
+        () => LogsService.requestDownload(this.selected, false),
+        (data) => `Queued ${data.queued} log(s) for download`
+      );
+    },
+
+    uploadSelected() {
+      const ids = this.uploadableSelected.map((log) => log.id);
+      this.run(
+        () => LogsService.requestUpload(ids),
+        (data) => `Queued ${data.queued} log(s) for upload`
+      );
+    },
+
+    cancelSelected() {
+      const ids = this.cancellableSelected.map((log) => log.id);
+      this.run(
+        () => LogsService.cancelRequests(ids),
+        (data) => `Cancelled ${data.cancelled} pending request(s)`
+      );
+    },
+
+    deleteFile(log) {
+      this.run(
+        () => LogsService.deleteLocalFile(log.id),
+        () => `Deleted the local copy of ${log.name}`
+      );
+    },
+
+    toggleAll(event) {
+      this.selected = event.target.checked ? this.logs.map((log) => log.id) : [];
+    },
+
+    uploadOf(log, target) {
+      return (log.uploads && log.uploads[target]) || {};
+    },
+
+    targetLabel(target) {
+      return target === 'local' ? 'Flight Review' : 'Remote';
+    },
+
+    plotUrl(target, location) {
+      return target === 'local' ? `${LOCAL_FLIGHT_REVIEW_PREFIX}${location}` : location;
+    },
+
+    formatSize(bytes) {
+      if (!bytes) return '-';
+      if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+      return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    },
+
+    formatDate(date) {
+      if (!date) return '-';
+      const parsed = new Date(date);
+      if (Number.isNaN(parsed.getTime())) return date;
+      const p = (n) => String(n).padStart(2, '0');
+      return `${parsed.getFullYear()}-${p(parsed.getMonth() + 1)}-${p(parsed.getDate())} `
+        + `${p(parsed.getHours())}:${p(parsed.getMinutes())}`;
+    },
+
+    retry() {
+      this.loading = true;
+      this.error = null;
+      this.fetchLogs();
+      this.connectStream();
+    },
+  },
+};
+</script>
+
+<style scoped>
+.page-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 20px;
+  padding-right: 40px;
+  gap: 24px;
+  box-sizing: border-box;
+}
+
+.page-title {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--ark-color-black);
+  margin: 0;
+  text-align: center;
+}
+
+.logs-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section-container {
+  width: 100%;
+  box-shadow: 0 2px 8px var(--ark-color-black-shadow);
+  background-color: var(--ark-color-white);
+  border-radius: 8px;
+  padding: 20px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--ark-color-black-shadow);
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.section-title {
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--ark-color-black);
+  margin: 0;
+}
+
+.status-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  align-items: center;
+  color: var(--ark-color-black);
+  font-size: 0.9rem;
+}
+
+.status-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-item.warning {
+  color: var(--ark-color-orange);
+  font-weight: 600;
+}
+
+.status-item.counts {
+  margin-left: auto;
+  color: var(--ark-color-grey);
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.dot-ok {
+  background-color: var(--ark-color-green);
+}
+
+.dot-bad {
+  background-color: var(--ark-color-red);
+}
+
+.actions-bar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.action-button {
+  padding: 8px 14px;
+  border: 1px solid var(--ark-color-black-shadow);
+  background-color: var(--ark-color-white);
+  color: var(--ark-color-black);
+  border-radius: 4px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s, opacity 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.action-button:hover:not(:disabled) {
+  background-color: var(--ark-color-light-grey);
+}
+
+.action-button.primary {
+  background-color: var(--ark-color-green);
+  border-color: var(--ark-color-green);
+  color: var(--ark-color-white);
+}
+
+.action-button.primary:hover:not(:disabled) {
+  background-color: var(--ark-color-green-hover);
+}
+
+.action-button.danger {
+  color: var(--ark-color-red);
+}
+
+.action-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.message {
+  margin: 0 0 16px 0;
+  color: var(--ark-color-grey);
+  font-size: 0.9rem;
+}
+
+.table-container {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: 4px;
+  border: 1px solid var(--ark-color-black-shadow);
+}
+
+.logs-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.logs-table th {
+  background-color: var(--ark-color-light-grey);
+  padding: 12px;
+  text-align: left;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--ark-color-black);
+  border-bottom: 1px solid var(--ark-color-black-shadow);
+  white-space: nowrap;
+}
+
+.logs-table td {
+  padding: 12px;
+  border-bottom: 1px solid var(--ark-color-black-shadow);
+  color: var(--ark-color-black);
+}
+
+.logs-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.logs-table tbody tr.active-row {
+  background-color: var(--ark-color-green-shadow);
+}
+
+.checkbox-cell {
+  width: 40px;
+}
+
+.nowrap {
+  white-space: nowrap;
+}
+
+.name-cell {
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+
+.state-ok {
+  color: var(--ark-color-green);
+}
+
+.state-bad {
+  color: var(--ark-color-red);
+}
+
+.state-pending {
+  color: var(--ark-color-blue);
+}
+
+.state-muted {
+  color: #999;
+}
+
+.progress {
+  position: relative;
+  width: 90px;
+  height: 16px;
+  background-color: var(--ark-color-light-grey);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background-color: var(--ark-color-green);
+  transition: width 0.3s;
+}
+
+.progress-text {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  color: var(--ark-color-black-bold);
+}
+
+.plot-link {
+  color: var(--ark-color-blue);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+}
+
+.plot-link:hover {
+  text-decoration: underline;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 24px;
+}
+
+.icon-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+  color: var(--ark-color-grey);
+}
+
+.icon-button.danger:hover {
+  color: var(--ark-color-red);
+  background-color: var(--ark-color-light-grey);
+}
+
+.row-error {
+  color: var(--ark-color-orange);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 40px;
+}
+
+.empty-message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  color: var(--ark-color-grey);
+}
+
+.empty-message i {
+  font-size: 2rem;
+}
+
+.loading-container,
+.error-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 40px;
+  min-height: 400px;
+}
+
+.loading-container i {
+  font-size: 2.5rem;
+  color: var(--ark-color-blue);
+}
+
+.error-container i {
+  font-size: 3rem;
+  color: var(--ark-color-orange);
+}
+
+.retry-button {
+  padding: 10px 20px;
+  background-color: var(--ark-color-blue);
+  color: var(--ark-color-white);
+  border: none;
+  border-radius: 4px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.retry-button:hover {
+  background-color: var(--ark-color-blue-hover);
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/frontend/src/pages/LogsPage.vue
+++ b/frontend/src/pages/LogsPage.vue
@@ -27,6 +27,9 @@
             <span class="dot" :class="status.ftp_available ? 'dot-ok' : 'dot-bad'"></span>
             {{ status.ftp_available ? `MAVLink FTP: ${status.log_root}` : 'MAVLink FTP unavailable' }}
           </span>
+          <span class="status-item" v-if="status.logging">
+            <span class="dot dot-ok"></span> Logger running
+          </span>
           <span class="status-item warning" v-if="!streamConnected">
             <i class="fas fa-exclamation-triangle"></i> Live updates disconnected — reconnecting
           </span>
@@ -59,6 +62,10 @@
             <button class="action-button danger" :disabled="!cancellableSelected.length || busy"
               @click="cancelSelected">
               <i class="fas fa-times"></i> Cancel
+            </button>
+            <button class="action-button" :disabled="busy" @click="refreshVehicle"
+              title="List the vehicle's logs again">
+              <i class="fas fa-sync-alt"></i> Refresh
             </button>
           </div>
         </div>
@@ -210,6 +217,9 @@ export default {
   mounted() {
     this.fetchLogs();
     this.connectStream();
+    // Nothing polls the vehicle; ask for a fresh listing now that someone is
+    // actually looking. Ignored until the vehicle is connected and disarmed.
+    LogsService.refresh().catch(() => {});
   },
   beforeUnmount() {
     this.disconnectStream();
@@ -343,6 +353,14 @@ export default {
         () => LogsService.cancelRequests(ids),
         (data) => `Cancelled ${data.cancelled} pending request(s)`
       );
+    },
+
+    refreshVehicle() {
+      // Fire-and-forget: the new listing arrives over the event stream.
+      LogsService.refresh().catch(() => {});
+      this.setMessage(this.status.connected
+        ? 'Checking the vehicle for logs…'
+        : 'Refresh queued; it runs when the vehicle reconnects');
     },
 
     deleteFile(log) {

--- a/frontend/src/pages/LogsPage.vue
+++ b/frontend/src/pages/LogsPage.vue
@@ -27,6 +27,9 @@
             <span class="dot" :class="status.ftp_available ? 'dot-ok' : 'dot-bad'"></span>
             {{ status.ftp_available ? `MAVLink FTP: ${status.log_root}` : 'MAVLink FTP unavailable' }}
           </span>
+          <span class="status-item warning" v-if="!streamConnected">
+            <i class="fas fa-exclamation-triangle"></i> Live updates disconnected — reconnecting
+          </span>
           <span class="status-item warning" v-if="status.armed">
             <i class="fas fa-exclamation-triangle"></i> Armed — transfers are paused
           </span>
@@ -68,14 +71,14 @@
               <tr>
                 <th class="checkbox-cell">
                   <input type="checkbox" :checked="allSelected" :indeterminate.prop="someSelected"
-                    @change="toggleAll" title="Select all">
+                    :disabled="!logs.length" @change="toggleAll" title="Select all">
                 </th>
                 <th>Date (local)</th>
                 <th>Name</th>
                 <th>Size</th>
                 <th>On Vehicle</th>
                 <th>Downloaded</th>
-                <th v-for="target in targets" :key="target">{{ targetLabel(target) }}</th>
+                <th v-for="target in targets" :key="target.name">{{ targetLabel(target.name) }}</th>
                 <th>Actions</th>
               </tr>
             </thead>
@@ -100,18 +103,18 @@
                   <i v-else-if="log.download_requested" class="fas fa-clock state-pending" title="Queued"></i>
                   <i v-else class="fas fa-minus state-muted"></i>
                 </td>
-                <td v-for="target in targets" :key="target">
-                  <a v-if="uploadOf(log, target).uploaded && uploadOf(log, target).location"
-                    :href="plotUrl(target, uploadOf(log, target).location)" target="_blank"
+                <td v-for="target in targets" :key="target.name">
+                  <a v-if="uploadOf(log, target.name).uploaded && uploadOf(log, target.name).location"
+                    :href="plotUrl(target, uploadOf(log, target.name).location)" target="_blank"
                     rel="noopener noreferrer" class="plot-link" title="Open in Flight Review">
                     <i class="fas fa-external-link-alt"></i> View
                   </a>
-                  <i v-else-if="uploadOf(log, target).uploaded" class="fas fa-check state-ok"></i>
-                  <i v-else-if="log.id === status.uploading_id && status.uploading_target === target"
+                  <i v-else-if="uploadOf(log, target.name).uploaded" class="fas fa-check state-ok"></i>
+                  <i v-else-if="log.id === status.uploading_id && status.uploading_target === target.name"
                     class="fas fa-spinner fa-spin state-pending" title="Uploading"></i>
-                  <i v-else-if="uploadOf(log, target).rejected" class="fas fa-ban state-bad"
-                    :title="uploadOf(log, target).message"></i>
-                  <i v-else-if="uploadOf(log, target).requested" class="fas fa-clock state-pending"
+                  <i v-else-if="uploadOf(log, target.name).rejected" class="fas fa-ban state-bad"
+                    :title="uploadOf(log, target.name).message"></i>
+                  <i v-else-if="uploadOf(log, target.name).requested" class="fas fa-clock state-pending"
                     title="Queued"></i>
                   <i v-else class="fas fa-minus state-muted"></i>
                 </td>
@@ -146,9 +149,10 @@
 <script>
 import LogsService from '@/services/LogsService';
 
-// logloader only ever reports the path Flight Review redirected to. The origin
-// is added here so the link works from whatever host the browser is on, which
-// is not the 127.0.0.1 logloader itself uploaded to.
+// logloader only ever reports the path Flight Review redirected to, because
+// that is all the server sends back. The local instance is reachable through
+// nginx on whatever host the browser is on -- not the 127.0.0.1 logloader
+// uploaded to -- so it gets the proxy prefix; a remote one gets its own origin.
 const LOCAL_FLIGHT_REVIEW_PREFIX = '/flight-review';
 
 export default {
@@ -163,7 +167,9 @@ export default {
       error: null,
       busy: false,
       message: '',
+      streamConnected: false,
       eventSource: null,
+      messageTimer: null,
     };
   },
   computed: {
@@ -171,7 +177,7 @@ export default {
       return this.logs.filter((log) => log.downloaded).length;
     },
     uploadedCount() {
-      return this.logs.filter((log) => this.targets.some((t) => this.uploadOf(log, t).uploaded)).length;
+      return this.logs.filter((log) => this.targets.some((t) => this.uploadOf(log, t.name).uploaded)).length;
     },
     allSelected() {
       return this.logs.length > 0 && this.selected.length === this.logs.length;
@@ -187,12 +193,12 @@ export default {
     uploadableSelected() {
       return this.selectedLogs.filter(
         (log) => (log.downloaded || log.present)
-          && this.targets.some((t) => !this.uploadOf(log, t).uploaded)
+          && this.targets.some((t) => !this.uploadOf(log, t.name).uploaded)
       );
     },
     cancellableSelected() {
       return this.selectedLogs.filter(
-        (log) => log.download_requested || this.targets.some((t) => this.uploadOf(log, t).requested)
+        (log) => log.download_requested || this.targets.some((t) => this.uploadOf(log, t.name).requested)
       );
     },
     downloadPercent() {
@@ -207,9 +213,11 @@ export default {
   },
   beforeUnmount() {
     this.disconnectStream();
+    clearTimeout(this.messageTimer);
   },
   methods: {
     async fetchLogs() {
+      this.loading = true;
       try {
         const response = await LogsService.getLogs();
         this.applyPayload(response.data);
@@ -240,6 +248,8 @@ export default {
       const source = new EventSource(LogsService.eventsUrl());
       this.eventSource = source;
 
+      source.onopen = () => { this.streamConnected = true; };
+
       // The full list only arrives when it changed. Transfer progress ticks
       // several times a second and comes through as `status` alone.
       source.addEventListener('logs', (event) => {
@@ -256,7 +266,9 @@ export default {
       });
 
       source.onerror = () => {
-        // Connection-level only; EventSource reconnects on its own.
+        // EventSource reconnects on its own; say so rather than showing a table
+        // that has quietly stopped changing.
+        this.streamConnected = false;
       };
     },
 
@@ -273,18 +285,27 @@ export default {
         this.eventSource.close();
         this.eventSource = null;
       }
+      this.streamConnected = false;
     },
 
     async run(action, describe) {
       this.busy = true;
-      this.message = '';
+      this.setMessage('');
       try {
         const response = await action();
-        this.message = describe(response.data);
+        this.setMessage(describe(response.data));
       } catch (error) {
-        this.message = error.response?.data?.error || error.message || 'Request failed';
+        this.setMessage(error.response?.data?.error || error.message || 'Request failed');
       } finally {
         this.busy = false;
+      }
+    },
+
+    setMessage(text) {
+      clearTimeout(this.messageTimer);
+      this.message = text;
+      if (text) {
+        this.messageTimer = setTimeout(() => { this.message = ''; }, 8000);
       }
     },
 
@@ -303,9 +324,15 @@ export default {
     },
 
     uploadSelected() {
-      const ids = this.uploadableSelected.map((log) => log.id);
+      const logs = this.uploadableSelected;
+      const ids = logs.map((log) => log.id);
+      // Only the targets that are actually missing one of these logs, so a
+      // request cannot re-queue a target that already has them all.
+      const targets = this.targets
+        .filter((t) => logs.some((log) => !this.uploadOf(log, t.name).uploaded))
+        .map((t) => t.name);
       this.run(
-        () => LogsService.requestUpload(ids),
+        () => LogsService.requestUpload(ids, targets),
         (data) => `Queued ${data.queued} log(s) for upload`
       );
     },
@@ -319,6 +346,10 @@ export default {
     },
 
     deleteFile(log) {
+      if (!window.confirm(`Delete the downloaded copy of ${log.name}? `
+        + 'It can be fetched again while it is still on the vehicle.')) {
+        return;
+      }
       this.run(
         () => LogsService.deleteLocalFile(log.id),
         () => `Deleted the local copy of ${log.name}`
@@ -338,7 +369,8 @@ export default {
     },
 
     plotUrl(target, location) {
-      return target === 'local' ? `${LOCAL_FLIGHT_REVIEW_PREFIX}${location}` : location;
+      if (target.name === 'local') return `${LOCAL_FLIGHT_REVIEW_PREFIX}${location}`;
+      return target.url ? `${target.url.replace(/\/$/, '')}${location}` : location;
     },
 
     formatSize(bytes) {
@@ -575,7 +607,7 @@ export default {
 }
 
 .state-muted {
-  color: #999;
+  color: var(--ark-color-grey);
 }
 
 .progress {

--- a/frontend/src/pages/LogsPage.vue
+++ b/frontend/src/pages/LogsPage.vue
@@ -127,7 +127,7 @@
                 </td>
                 <td>
                   <div class="actions">
-                    <button v-if="log.downloaded" class="icon-button danger"
+                    <button v-if="log.downloaded" class="icon-button danger" :disabled="busy"
                       title="Delete the downloaded copy" @click="deleteFile(log)">
                       <i class="fas fa-trash"></i>
                     </button>
@@ -177,6 +177,7 @@ export default {
       streamConnected: false,
       eventSource: null,
       messageTimer: null,
+      reconnectTimer: null,
     };
   },
   computed: {
@@ -276,9 +277,19 @@ export default {
       });
 
       source.onerror = () => {
-        // EventSource reconnects on its own; say so rather than showing a table
-        // that has quietly stopped changing.
+        // Say so rather than showing a table that has quietly stopped changing.
         this.streamConnected = false;
+
+        // EventSource retries network failures on its own, but an HTTP error --
+        // the gateway's 502 while logloader restarts -- closes it for good, so
+        // that retry is ours. fetchLogs resyncs whatever the dead stream missed.
+        if (source.readyState === EventSource.CLOSED) {
+          clearTimeout(this.reconnectTimer);
+          this.reconnectTimer = setTimeout(() => {
+            this.fetchLogs();
+            this.connectStream();
+          }, 3000);
+        }
       };
     },
 
@@ -291,6 +302,7 @@ export default {
     },
 
     disconnectStream() {
+      clearTimeout(this.reconnectTimer);
       if (this.eventSource) {
         this.eventSource.close();
         this.eventSource = null;

--- a/frontend/src/pages/components/TomlEditor.vue
+++ b/frontend/src/pages/components/TomlEditor.vue
@@ -143,6 +143,13 @@
                 <div v-else-if="Array.isArray(tableValue[subKey])" class="array-display">
                   {{ JSON.stringify(tableValue[subKey]) }}
                 </div>
+
+                <!-- Anything else, which in practice means a table nested two
+                     deep. Nothing rendered here before, so the field simply
+                     vanished from the form; say so instead. -->
+                <div v-else class="unsupported-field">
+                  Not editable here — change this in the config file directly.
+                </div>
               </div>
             </div>
           </div>
@@ -444,6 +451,12 @@ export default {
 </script>
 
 <style scoped>
+.unsupported-field {
+  font-size: 0.85rem;
+  color: var(--ark-color-grey);
+  font-style: italic;
+}
+
 .editor-backdrop {
   position: fixed;
   top: 0;

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -4,6 +4,7 @@ import ConnectionsPage from '../pages/ConnectionsPage.vue';
 import AutopilotPage from '../pages/AutopilotPage.vue';
 import SystemPage from '../pages/SystemPage.vue';
 import VideoPage from '../pages/VideoPage.vue';
+import LogsPage from '../pages/LogsPage.vue';
 
 const routes = [
   {
@@ -30,6 +31,11 @@ const routes = [
     path: '/video-page',
     name: 'VideoPage',
     component: VideoPage
+  },
+  {
+    path: '/logs-page',
+    name: 'LogsPage',
+    component: LogsPage
   }
 ];
 

--- a/frontend/src/services/LogsService.js
+++ b/frontend/src/services/LogsService.js
@@ -1,0 +1,46 @@
+import axios from 'axios';
+
+const ENDPOINTS = {
+  logs: `/api/logloader/logs`,
+  status: `/api/logloader/status`,
+  events: `/api/logloader/events`,
+  download: `/api/logloader/logs/download`,
+  upload: `/api/logloader/logs/upload`,
+  cancel: `/api/logloader/logs/cancel`,
+  localFile: (id) => `/api/logloader/logs/${id}/file`,
+};
+
+export default {
+  async getLogs() {
+    return axios.get(ENDPOINTS.logs);
+  },
+
+  async getStatus() {
+    return axios.get(ENDPOINTS.status);
+  },
+
+  // Queues a download, and an upload of the same logs unless upload is false.
+  async requestDownload(ids, upload = true) {
+    return axios.post(ENDPOINTS.download, { ids, upload });
+  },
+
+  async requestDownloadAll(upload = true) {
+    return axios.post(ENDPOINTS.download, { all: true, upload });
+  },
+
+  async requestUpload(ids, targets) {
+    return axios.post(ENDPOINTS.upload, targets ? { ids, targets } : { ids });
+  },
+
+  async cancelRequests(ids) {
+    return axios.post(ENDPOINTS.cancel, { ids });
+  },
+
+  async deleteLocalFile(id) {
+    return axios.delete(ENDPOINTS.localFile(id));
+  },
+
+  eventsUrl() {
+    return ENDPOINTS.events;
+  },
+};

--- a/frontend/src/services/LogsService.js
+++ b/frontend/src/services/LogsService.js
@@ -4,6 +4,7 @@ const ENDPOINTS = {
   logs: `/api/logloader/logs`,
   status: `/api/logloader/status`,
   events: `/api/logloader/events`,
+  refresh: `/api/logloader/refresh`,
   download: `/api/logloader/logs/download`,
   upload: `/api/logloader/logs/upload`,
   cancel: `/api/logloader/logs/cancel`,
@@ -17,6 +18,12 @@ export default {
 
   async getStatus() {
     return axios.get(ENDPOINTS.status);
+  },
+
+  // Asks logloader to list the vehicle again — nothing polls, so this is how
+  // the page gets a current listing. Changes arrive over /events.
+  async refresh() {
+    return axios.post(ENDPOINTS.refresh);
   },
 
   // Queues a download, and an upload of the same logs unless upload is false.

--- a/frontend/src/services/LogsService.js
+++ b/frontend/src/services/LogsService.js
@@ -29,7 +29,7 @@ export default {
   },
 
   async requestUpload(ids, targets) {
-    return axios.post(ENDPOINTS.upload, targets ? { ids, targets } : { ids });
+    return axios.post(ENDPOINTS.upload, targets && targets.length ? { ids, targets } : { ids });
   },
 
   async cancelRequests(ids) {

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,6 +1,11 @@
 // vue.config.js
 module.exports = {
   devServer: {
+    // The dev server gzips responses by default, and its compression middleware
+    // buffers until it has enough bytes -- which for an SSE stream is never.
+    // Every /api/.../stream and /events endpoint hangs at readyState 0 under
+    // `npm run serve` with it on. nginx does not do this in production.
+    compress: false,
     proxy: {
       // All API requests go through the Express server
       '/api': {
@@ -11,6 +16,8 @@ module.exports = {
       '/flight-review': {
         target: 'http://localhost:5006',
         changeOrigin: true,
+        // Bokeh's plot page opens a websocket under this prefix.
+        ws: true,
         pathRewrite: { '^/flight-review': '' }
       }
     }

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -6,6 +6,12 @@ module.exports = {
       '/api': {
         target: 'http://localhost:3000',
         changeOrigin: true
+      },
+      // nginx serves this in production; the Logs page links plots here.
+      '/flight-review': {
+        target: 'http://localhost:5006',
+        changeOrigin: true,
+        pathRewrite: { '^/flight-review': '' }
       }
     }
   }

--- a/packaging/DEBIAN/postinst
+++ b/packaging/DEBIAN/postinst
@@ -180,6 +180,14 @@ chown -R "$ARK_USER:$ARK_USER" /var/lib/ark-os
 # ===========================================================================
 mkdir -p /etc/ark-os
 if [ -x /usr/lib/ark-os/venv/bin/python3 ] && [ -d /usr/lib/ark-os/config-defaults ]; then
+    # logloader.toml moved from flat keys to nested tables. merge_configs takes
+    # its structure from the template and prunes scalars the template lacks,
+    # which for a *renamed* key means silently discarding the operator's value —
+    # a vehicle set up to upload to a remote Flight Review would just stop.
+    # Translating first turns the rename into an ordinary merge.
+    /usr/lib/ark-os/venv/bin/python3 /usr/lib/ark-os/libexec/migrate_logloader_config.py \
+        /etc/ark-os/logloader.toml /var/lib/ark-os/.config-backup/logloader.toml || true
+
     /usr/lib/ark-os/venv/bin/python3 /usr/lib/ark-os/libexec/merge_configs.py \
         /usr/lib/ark-os/config-defaults /var/lib/ark-os/.config-backup /etc/ark-os || true
 fi

--- a/packaging/assemble_tree.sh
+++ b/packaging/assemble_tree.sh
@@ -116,6 +116,7 @@ for f in packaging/config/*; do
     install -m 0644 "$f" "$DEFAULTS/$base"
 done
 install -m 0755 packaging/system-config/merge_configs.py "$PKG$ARK/libexec/merge_configs.py"
+install -m 0755 packaging/system-config/migrate_logloader_config.py "$PKG$ARK/libexec/migrate_logloader_config.py"
 
 # --- nginx site ---
 install -m 0644 frontend/ark-ui.nginx "$PKG/etc/nginx/sites-available/ark-ui"

--- a/packaging/config/logloader.toml
+++ b/packaging/config/logloader.toml
@@ -35,12 +35,12 @@ remote_directory = ""
 auto = true
 
 # Flight Review on this companion, reachable at /flight-review.
-[upload.local]
+[upload_local]
 enabled = true
 url = "http://127.0.0.1:5006"
 public = true
 
-[upload.remote]
+[upload_remote]
 enabled = false
 url = "https://review.px4.io"
 email = ""

--- a/packaging/config/logloader.toml
+++ b/packaging/config/logloader.toml
@@ -1,8 +1,51 @@
 connection_url = "udp://:14551"
-local_server = "http://127.0.0.1:5006"
-remote_server = "https://review.px4.io"
+
+# error | warn | info | debug
+log_level = "info"
+
+[data]
+# Where logloader stages downloaded ulogs and keeps its database
+# (FHS runtime data dir, created by postinst).
+directory = "/var/lib/ark-os/logs/"
+
+# Local API the ARK-OS Logs page talks to, via the ark-ui-backend gateway.
+[api]
+enabled = true
+bind = "127.0.0.1"
+port = 3005
+
+[download]
+# Fetch a log as soon as it appears, which in practice means after a flight.
+auto = true
+
+# On a database that has never seen this vehicle every log looks new. Rather
+# than pull a whole SD card the first time logloader runs, take only the most
+# recent one; everything else is available from the Logs page.
+latest_on_first_start = true
+
+# A listing with more new logs than this is an unfamiliar card, not a burst of
+# flights: queue only the newest. 0 disables the guard.
+max_auto_queue = 5
+
+# Empty probes "@MAV_LOG", then /fs/microsd/log and /APM/LOGS.
+remote_directory = ""
+
+[upload]
+# Upload what was fetched automatically.
+auto = true
+
+# Flight Review on this companion, reachable at /flight-review.
+[upload.local]
+enabled = true
+url = "http://127.0.0.1:5006"
+public = true
+
+[upload.remote]
+enabled = false
+url = "https://review.px4.io"
 email = ""
-upload_enabled = false
-public_logs = false
-# Where logloader stages downloaded ulogs (FHS runtime data dir, created by postinst).
-application_directory = "/var/lib/ark-os/logs/"
+public = false
+
+# Per-account key for an authenticated Flight Review. Empty sends no auth
+# headers at all, which is what open servers expect.
+api_key = ""

--- a/packaging/config/logloader.toml
+++ b/packaging/config/logloader.toml
@@ -30,6 +30,10 @@ max_auto_queue = 5
 # Empty probes "@MAV_LOG", then /fs/microsd/log and /APM/LOGS.
 remote_directory = ""
 
+# FTP burst reads. Much faster; disable if the flight stack's burst support
+# misbehaves.
+use_burst = true
+
 [upload]
 # Upload what was fetched automatically.
 auto = true

--- a/packaging/system-config/migrate_logloader_config.py
+++ b/packaging/system-config/migrate_logloader_config.py
@@ -20,12 +20,12 @@ except Exception:
 
 # Old flat key -> where it lives now.
 RENAMES = {
-    'local_server': ('upload', 'local', 'url'),
-    'remote_server': ('upload', 'remote', 'url'),
-    'email': ('upload', 'remote', 'email'),
-    'upload_enabled': ('upload', 'remote', 'enabled'),
-    'public_logs': ('upload', 'remote', 'public'),
-    'remote_api_key': ('upload', 'remote', 'api_key'),
+    'local_server': ('upload_local', 'url'),
+    'remote_server': ('upload_remote', 'url'),
+    'email': ('upload_remote', 'email'),
+    'upload_enabled': ('upload_remote', 'enabled'),
+    'public_logs': ('upload_remote', 'public'),
+    'remote_api_key': ('upload_remote', 'api_key'),
     'application_directory': ('data', 'directory'),
     'remote_log_directory': ('download', 'remote_directory'),
     'ftp_use_burst': ('download', 'use_burst'),
@@ -45,7 +45,7 @@ def migrate(path: str) -> bool:
         return False
 
     # Already migrated, or written against the new layout to begin with.
-    if 'upload' in config or not any(key in config for key in RENAMES):
+    if 'upload_local' in config or 'upload_remote' in config or not any(key in config for key in RENAMES):
         return False
 
     for flat, destination in RENAMES.items():
@@ -62,7 +62,7 @@ def migrate(path: str) -> bool:
         table.setdefault(destination[-1], value)
 
     # local uploads used to be implicit and always on.
-    config.setdefault('upload', {}).setdefault('local', {}).setdefault('enabled', True)
+    config.setdefault('upload_local', {}).setdefault('enabled', True)
 
     with open(path, 'w', encoding='utf-8') as handle:
         toml.dump(config, handle)

--- a/packaging/system-config/migrate_logloader_config.py
+++ b/packaging/system-config/migrate_logloader_config.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Rewrite a pre-3005 logloader.toml from its flat keys into the nested layout.
+
+merge_configs.py takes its structure from the new template and prunes scalars the
+template does not have. That is right for a removed field and wrong for a renamed
+one: without this step an upgrade would silently drop upload_enabled, remote_server
+and email, and a vehicle that had been uploading to a remote Flight Review would
+quietly stop.
+
+Runs from postinst, before merge_configs.py, over both the live config and the
+pre-upgrade backup. Idempotent: a file that already has [upload] is left alone.
+"""
+import sys
+import os
+
+try:
+    import toml
+except Exception:
+    toml = None
+
+# Old flat key -> where it lives now.
+RENAMES = {
+    'local_server': ('upload', 'local', 'url'),
+    'remote_server': ('upload', 'remote', 'url'),
+    'email': ('upload', 'remote', 'email'),
+    'upload_enabled': ('upload', 'remote', 'enabled'),
+    'public_logs': ('upload', 'remote', 'public'),
+    'remote_api_key': ('upload', 'remote', 'api_key'),
+    'application_directory': ('data', 'directory'),
+    'remote_log_directory': ('download', 'remote_directory'),
+    'ftp_use_burst': ('download', 'use_burst'),
+}
+
+
+def migrate(path: str) -> bool:
+    """Returns True when the file was rewritten."""
+    if not os.path.isfile(path):
+        return False
+
+    try:
+        config = toml.load(path)
+    except Exception as error:
+        print('migrate_logloader_config: cannot parse %s (%s), leaving it alone' % (path, error),
+              file=sys.stderr)
+        return False
+
+    # Already migrated, or written against the new layout to begin with.
+    if 'upload' in config or not any(key in config for key in RENAMES):
+        return False
+
+    for flat, destination in RENAMES.items():
+        if flat not in config:
+            continue
+
+        value = config.pop(flat)
+        table = config
+
+        for part in destination[:-1]:
+            table = table.setdefault(part, {})
+
+        # A value already set under the new name wins; this only fills gaps.
+        table.setdefault(destination[-1], value)
+
+    # local uploads used to be implicit and always on.
+    config.setdefault('upload', {}).setdefault('local', {}).setdefault('enabled', True)
+
+    with open(path, 'w', encoding='utf-8') as handle:
+        toml.dump(config, handle)
+
+    print('migrate_logloader_config: rewrote %s in the nested layout' % path)
+    return True
+
+
+def main() -> int:
+    if toml is None:
+        print('migrate_logloader_config: toml library unavailable, skipping', file=sys.stderr)
+        return 0
+
+    for path in sys.argv[1:]:
+        try:
+            migrate(path)
+        except Exception as error:
+            # Never fail an upgrade over this; the flat keys are still read by
+            # logloader itself as a fallback.
+            print('migrate_logloader_config: %s: %s' % (path, error), file=sys.stderr)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/services/ark-ui-backend/index.js
+++ b/services/ark-ui-backend/index.js
@@ -36,11 +36,15 @@ console.log(`- LOGLOADER_SERVICE_URL: ${LOGLOADER_SERVICE_URL}`);
 app.use('/api/service', createProxyMiddleware({
   target: SERVICE_MANAGER_URL,
   changeOrigin: true,
-  logLevel: 'warn',
-  onError: (err, req, res) => {
-    console.error(`Service proxy error: ${err.message}`);
-    res.writeHead(502, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Service service unavailable' }));
+  // http-proxy-middleware v3 reads handlers from `on`; the v2 `onError`/`logLevel`
+  // options are ignored, which left every proxy answering a dead upstream with
+  // the default plain-text 504 instead of the JSON the UI expects.
+  on: {
+    error: (err, req, res) => {
+      console.error(`Service proxy error: ${err.message}`);
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Service service unavailable' }));
+    }
   }
 }));
 
@@ -48,11 +52,15 @@ app.use('/api/service', createProxyMiddleware({
 app.use('/api/network', createProxyMiddleware({
   target: NETWORK_SERVICE_URL,
   changeOrigin: true,
-  logLevel: 'warn',
-  onError: (err, req, res) => {
-    console.error(`Network proxy error: ${err.message}`);
-    res.writeHead(502, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Network service unavailable' }));
+  // http-proxy-middleware v3 reads handlers from `on`; the v2 `onError`/`logLevel`
+  // options are ignored, which left every proxy answering a dead upstream with
+  // the default plain-text 504 instead of the JSON the UI expects.
+  on: {
+    error: (err, req, res) => {
+      console.error(`Network proxy error: ${err.message}`);
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Network service unavailable' }));
+    }
   }
 }));
 
@@ -60,11 +68,15 @@ app.use('/api/network', createProxyMiddleware({
 app.use('/api/autopilot', createProxyMiddleware({
   target: AUTOPILOT_SERVICE_URL,
   changeOrigin: true,
-  logLevel: 'warn',
-  onError: (err, req, res) => {
-    console.error(`Autopilot service proxy error: ${err.message}`);
-    res.writeHead(502, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Autopilot service unavailable' }));
+  // http-proxy-middleware v3 reads handlers from `on`; the v2 `onError`/`logLevel`
+  // options are ignored, which left every proxy answering a dead upstream with
+  // the default plain-text 504 instead of the JSON the UI expects.
+  on: {
+    error: (err, req, res) => {
+      console.error(`Autopilot service proxy error: ${err.message}`);
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Autopilot service unavailable' }));
+    }
   }
 }));
 
@@ -72,11 +84,15 @@ app.use('/api/autopilot', createProxyMiddleware({
 app.use('/api/system', createProxyMiddleware({
   target: SYSTEM_SERVICE_URL,
   changeOrigin: true,
-  logLevel: 'warn',
-  onError: (err, req, res) => {
-    console.error(`System service proxy error: ${err.message}`);
-    res.writeHead(502, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'System service unavailable' }));
+  // http-proxy-middleware v3 reads handlers from `on`; the v2 `onError`/`logLevel`
+  // options are ignored, which left every proxy answering a dead upstream with
+  // the default plain-text 504 instead of the JSON the UI expects.
+  on: {
+    error: (err, req, res) => {
+      console.error(`System service proxy error: ${err.message}`);
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'System service unavailable' }));
+    }
   }
 }));
 
@@ -85,11 +101,15 @@ app.use('/api/system', createProxyMiddleware({
 app.use('/api/logloader', createProxyMiddleware({
   target: LOGLOADER_SERVICE_URL,
   changeOrigin: true,
-  logLevel: 'warn',
-  onError: (err, req, res) => {
-    console.error(`Logloader proxy error: ${err.message}`);
-    res.writeHead(502, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Logloader service unavailable' }));
+  // http-proxy-middleware v3 reads handlers from `on`; the v2 `onError`/`logLevel`
+  // options are ignored, which left every proxy answering a dead upstream with
+  // the default plain-text 504 instead of the JSON the UI expects.
+  on: {
+    error: (err, req, res) => {
+      console.error(`Logloader proxy error: ${err.message}`);
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Logloader service unavailable' }));
+    }
   }
 }));
 

--- a/services/ark-ui-backend/index.js
+++ b/services/ark-ui-backend/index.js
@@ -32,68 +32,53 @@ console.log(`- AUTOPILOT_SERVICE_URL: ${AUTOPILOT_SERVICE_URL}`);
 console.log(`- SYSTEM_SERVICE_URL: ${SYSTEM_SERVICE_URL}`);
 console.log(`- LOGLOADER_SERVICE_URL: ${LOGLOADER_SERVICE_URL}`);
 
+// http-proxy-middleware v3 reads handlers from `on`; the v2 `onError`/`logLevel`
+// options are ignored, which left every proxy answering a dead upstream with
+// the default plain-text 504 instead of the JSON the UI expects. Supplying
+// `on.error` also replaces HPM's own error plugin, so its guards live here:
+// `res` can be a raw socket (upgraded request), and a response that already
+// streamed headers (SSE) cannot take a second writeHead -- the throw would
+// escape into a socket callback and take the whole gateway down.
+const proxyError = (label) => (err, req, res) => {
+  console.error(`${label} proxy error: ${err.message}`);
+  if (!res || typeof res.writeHead !== 'function') {
+    if (res && typeof res.destroy === 'function') res.destroy();
+    return;
+  }
+  if (res.headersSent) {
+    res.end();
+    return;
+  }
+  res.writeHead(502, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: `${label} service unavailable` }));
+};
+
 // Service proxy
 app.use('/api/service', createProxyMiddleware({
   target: SERVICE_MANAGER_URL,
   changeOrigin: true,
-  // http-proxy-middleware v3 reads handlers from `on`; the v2 `onError`/`logLevel`
-  // options are ignored, which left every proxy answering a dead upstream with
-  // the default plain-text 504 instead of the JSON the UI expects.
-  on: {
-    error: (err, req, res) => {
-      console.error(`Service proxy error: ${err.message}`);
-      res.writeHead(502, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Service service unavailable' }));
-    }
-  }
+  on: { error: proxyError('Service') }
 }));
 
 // Network proxy
 app.use('/api/network', createProxyMiddleware({
   target: NETWORK_SERVICE_URL,
   changeOrigin: true,
-  // http-proxy-middleware v3 reads handlers from `on`; the v2 `onError`/`logLevel`
-  // options are ignored, which left every proxy answering a dead upstream with
-  // the default plain-text 504 instead of the JSON the UI expects.
-  on: {
-    error: (err, req, res) => {
-      console.error(`Network proxy error: ${err.message}`);
-      res.writeHead(502, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Network service unavailable' }));
-    }
-  }
+  on: { error: proxyError('Network') }
 }));
 
 // Autopilot proxy
 app.use('/api/autopilot', createProxyMiddleware({
   target: AUTOPILOT_SERVICE_URL,
   changeOrigin: true,
-  // http-proxy-middleware v3 reads handlers from `on`; the v2 `onError`/`logLevel`
-  // options are ignored, which left every proxy answering a dead upstream with
-  // the default plain-text 504 instead of the JSON the UI expects.
-  on: {
-    error: (err, req, res) => {
-      console.error(`Autopilot service proxy error: ${err.message}`);
-      res.writeHead(502, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Autopilot service unavailable' }));
-    }
-  }
+  on: { error: proxyError('Autopilot') }
 }));
 
 // System proxy
 app.use('/api/system', createProxyMiddleware({
   target: SYSTEM_SERVICE_URL,
   changeOrigin: true,
-  // http-proxy-middleware v3 reads handlers from `on`; the v2 `onError`/`logLevel`
-  // options are ignored, which left every proxy answering a dead upstream with
-  // the default plain-text 504 instead of the JSON the UI expects.
-  on: {
-    error: (err, req, res) => {
-      console.error(`System service proxy error: ${err.message}`);
-      res.writeHead(502, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'System service unavailable' }));
-    }
-  }
+  on: { error: proxyError('System') }
 }));
 
 // Logloader proxy. Carries an SSE stream (/api/logloader/events), so buffering
@@ -101,16 +86,7 @@ app.use('/api/system', createProxyMiddleware({
 app.use('/api/logloader', createProxyMiddleware({
   target: LOGLOADER_SERVICE_URL,
   changeOrigin: true,
-  // http-proxy-middleware v3 reads handlers from `on`; the v2 `onError`/`logLevel`
-  // options are ignored, which left every proxy answering a dead upstream with
-  // the default plain-text 504 instead of the JSON the UI expects.
-  on: {
-    error: (err, req, res) => {
-      console.error(`Logloader proxy error: ${err.message}`);
-      res.writeHead(502, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Logloader service unavailable' }));
-    }
-  }
+  on: { error: proxyError('Logloader') }
 }));
 
 // NOW add body parsing middleware AFTER all proxies

--- a/services/ark-ui-backend/index.js
+++ b/services/ark-ui-backend/index.js
@@ -23,12 +23,14 @@ const NETWORK_SERVICE_URL = process.env.NETWORK_SERVICE_URL || 'http://localhost
 const SERVICE_MANAGER_URL = process.env.SERVICE_MANAGER_URL || 'http://localhost:3002';
 const AUTOPILOT_SERVICE_URL = process.env.AUTOPILOT_SERVICE_URL || 'http://localhost:3003';
 const SYSTEM_SERVICE_URL = process.env.SYSTEM_SERVICE_URL || 'http://localhost:3004';
+const LOGLOADER_SERVICE_URL = process.env.LOGLOADER_SERVICE_URL || 'http://localhost:3005';
 
 console.log('Service URLs:');
 console.log(`- NETWORK_SERVICE_URL: ${NETWORK_SERVICE_URL}`);
 console.log(`- SERVICE_MANAGER_URL: ${SERVICE_MANAGER_URL}`);
 console.log(`- AUTOPILOT_SERVICE_URL: ${AUTOPILOT_SERVICE_URL}`);
 console.log(`- SYSTEM_SERVICE_URL: ${SYSTEM_SERVICE_URL}`);
+console.log(`- LOGLOADER_SERVICE_URL: ${LOGLOADER_SERVICE_URL}`);
 
 // Service proxy
 app.use('/api/service', createProxyMiddleware({
@@ -78,6 +80,19 @@ app.use('/api/system', createProxyMiddleware({
   }
 }));
 
+// Logloader proxy. Carries an SSE stream (/api/logloader/events), so buffering
+// must stay off for it to be of any use.
+app.use('/api/logloader', createProxyMiddleware({
+  target: LOGLOADER_SERVICE_URL,
+  changeOrigin: true,
+  logLevel: 'warn',
+  onError: (err, req, res) => {
+    console.error(`Logloader proxy error: ${err.message}`);
+    res.writeHead(502, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Logloader service unavailable' }));
+  }
+}));
+
 // NOW add body parsing middleware AFTER all proxies
 app.use(express.json());
 
@@ -89,7 +104,8 @@ app.get('/health', (req, res) => {
       network: { url: NETWORK_SERVICE_URL },
       service: { url: SERVICE_MANAGER_URL },
       autopilot: { url: AUTOPILOT_SERVICE_URL },
-      system: { url: SYSTEM_SERVICE_URL }
+      system: { url: SYSTEM_SERVICE_URL },
+      logloader: { url: LOGLOADER_SERVICE_URL }
     }
   });
 });


### PR DESCRIPTION
## Summary

Adds a Logs page listing every log logloader knows about — on the vehicle, downloaded, uploaded — and lets the operator pick which ones to fetch and publish. Uploaded logs link straight to the plot in the onboard Flight Review.

Depends on ARK-Electronics/logloader#32, which the submodule bump points at; merge that first.

## Problem

logloader decided on its own what to download and upload, and there was no way to see what it had or to ask for a particular log. Its counterpart change makes fetching request-driven, which needs somewhere to make requests from.

Two things surfaced while wiring it up that are not specific to this page. The dev server gzips responses by default and its compression middleware buffers until it has enough bytes, which for an SSE stream is never — measured through `npm run serve` with a browser's `Accept-Encoding`: 0 bytes and an `EventSource` stuck at `readyState 0`, against 3332 bytes through the gateway. That has been silently breaking the journal viewer, the network-stats stream and the firmware-progress stream in dev too. Separately, http-proxy-middleware v3 reads handlers from `on`, so the v2 `onError`/`logLevel` options every proxy block uses are dead: a stopped upstream answers with the default plain-text 504 rather than the JSON the UI parses.

Upgrading an existing install was also unsafe. `merge_configs.py` takes its structure from the new template and prunes scalars the template lacks — right for a removed field, wrong for a renamed one. Simulating an upgrade of a real `logloader.toml` produced `[upload_remote] enabled = false` and the stock url, so a vehicle configured to upload to a remote Flight Review would silently stop.

## Solution

logloader serves a localhost API on :3005; the gateway proxies it at `/api/logloader`, including the SSE stream that drives live transfer progress. The page follows the house patterns: Options API, an axios service module, an inline `EventSource` with named events, and the SystemPage loading/error/retry triad.

Select all or a subset, then Download & Upload, Download Only, Upload, Cancel — or Refresh: logloader no longer polls the vehicle at all, so the page asks for a fresh listing when it loads and on demand, and a "Logger running" chip mirrors `MAV_SYS_STATUS_LOGGING` so it is visible why an automatic fetch is waiting. A log the vehicle is still writing never appears, so it cannot be selected at a size it will not keep. An upload records only the relative path Flight Review redirects to, so targets carry their base url and a remote plot link resolves against the right origin rather than the ARK-OS host.

`compress: false` on the dev server, `on: { error }` for all five proxies, and `migrate_logloader_config.py` run from postinst before the merge so a rename reaches `merge_configs` as an ordinary same-shape merge.

Review of the wiring found three more, all fixed here: supplying `on.error` in http-proxy-middleware v3 replaces its error plugin *and its guards*, so an upstream dying mid-SSE made `writeHead` throw on a response whose headers were long sent — an uncaught exception in a socket callback that took the whole gateway down; `EventSource` only retries network failures, so the gateway's 502 while the daemon restarts closed the stream for good and the page said "reconnecting" forever; and the migrated `download.use_burst` was absent from the new config template, so `merge_configs` pruned the very key the migration had just preserved.

logloader's config tables are one level deep because the shared `TomlEditor` renders exactly one level; with two, every upload setting silently vanished from the Services page config editor. The editor now says so rather than rendering nothing.

Verified against PX4 SITL, a local flight-review, and on hardware — a Jetson running this branch against an ARK FMU v6X on PX4 1.18, upgrading a real pre-FTP install: first launch queues only the newest log, a log closing mid-run is picked up automatically (logger cycles via nsh, end to end to a plot link in the onboard Flight Review), select-all fetches and publishes the rest, a restart re-downloads and re-uploads nothing, delete/re-fetch and cancel behave through the gateway, the SSE stream flows unbuffered through nginx and the dev server, and the pre-FTP database plus old-format config carries its state and settings across.
