### PR TITLE
feat(frontend): link to Thingstream signup from the PointPerfect config

### DIFF
--- a/frontend/src/pages/components/TomlEditor.vue
+++ b/frontend/src/pages/components/TomlEditor.vue
@@ -7,6 +7,18 @@
         <div class="toml-editor">
           <!-- Top-level primitive values first (skip *_options arrays used for dropdowns) -->
           <div v-for="key in topLevelFieldKeys" :key="key" class="form-group">
+            <!-- Where to sign up for the service account, shown with the credentials -->
+            <a
+              v-if="accountSignup && accountSignup.beforeField === key"
+              :href="accountSignup.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="signup-link"
+            >
+              <span class="signup-text">{{ accountSignup.text }}</span>
+              <span class="signup-cta">{{ accountSignup.cta }}</span>
+            </a>
+
             <label :for="key">{{ formatKey(key) }}</label>
 
             <!-- Dropdown when a sibling <field>_options array is present -->
@@ -138,6 +150,18 @@
 import axios from 'axios';
 import toml from 'toml-js';
 
+// Where customers sign up for the account a service needs credentials from,
+// keyed by service name. Rendered above the field named by beforeField so the
+// prompt sits with the credentials it belongs to.
+const ACCOUNT_SIGNUPS = {
+  pointperfect: {
+    beforeField: 'ntrip_username',
+    text: 'PointPerfect corrections require a u-blox Thingstream account.',
+    cta: 'Create an account',
+    url: 'https://portal.thingstream.io/register?token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJjdG9rOmYzNGRkMTg2LWNjYWUtNDZhMS1hNWRmLWRiM2UxYjMwZWI5MCIsImF1ZCI6IlRoaW5nc3RyZWFtIiwiY21wIjoicmVkZW1wdGlvbi1jYW1wYWlnbjphZmViMmY4OS05MDMzLTQ1YjAtOGE4NC0wZjBhZGVjMzA3MWUifQ.Y0gn8ai-0eJ7LVs8k1uthvj7LM0WSXhefR70p3l6w6XWBD9mrO99NYdal1NS7wfi1DGyM21TMExaXUnFoxVYSA'
+  }
+};
+
 export default {
   name: 'TomlEditor',
   props: {
@@ -154,6 +178,10 @@ export default {
     };
   },
   computed: {
+    // Account signup prompt for this service, if it needs one
+    accountSignup() {
+      return ACCOUNT_SIGNUPS[this.serviceName] || null;
+    },
     // Top-level editable fields (primitives + simple arrays that aren't *_options)
     topLevelFieldKeys() {
       return Object.keys(this.config).filter((key) => {
@@ -438,6 +466,46 @@ h1 {
   font-weight: 600;
   margin-bottom: 8px;
   color: var(--ark-color-black);
+}
+
+.signup-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 15px;
+  margin-bottom: 15px;
+  padding: 14px 16px;
+  background-color: var(--ark-color-light-grey);
+  border: 1px solid var(--ark-color-black-shadow);
+  border-left: 4px solid var(--ark-color-blue);
+  border-radius: 6px;
+  text-decoration: none;
+  transition: background-color 0.3s ease;
+}
+
+.signup-link:hover {
+  background-color: var(--ark-color-white);
+}
+
+.signup-text {
+  color: var(--ark-color-grey);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.signup-cta {
+  color: var(--ark-color-blue);
+  font-weight: 600;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.signup-cta::after {
+  content: ' \2192';
+}
+
+.signup-link:hover .signup-cta {
+  color: var(--ark-color-blue-hover);
 }
 
 .text-input,

--- a/frontend/src/pages/components/TomlEditor.vue
+++ b/frontend/src/pages/components/TomlEditor.vue
@@ -7,16 +7,17 @@
         <div class="toml-editor">
           <!-- Top-level primitive values first (skip *_options arrays used for dropdowns) -->
           <div v-for="key in topLevelFieldKeys" :key="key" class="form-group">
-            <!-- Where to sign up for the service account, shown with the credentials -->
+            <!-- Link callouts declared in the service's UI hints -->
             <a
-              v-if="accountSignup && accountSignup.beforeField === key"
-              :href="accountSignup.url"
+              v-for="callout in calloutsBefore(key)"
+              :key="callout.url"
+              :href="callout.url"
               target="_blank"
               rel="noopener noreferrer"
-              class="signup-link"
+              class="callout-link"
             >
-              <span class="signup-text">{{ accountSignup.text }}</span>
-              <span class="signup-cta">{{ accountSignup.cta }}</span>
+              <span class="callout-text">{{ callout.text }}</span>
+              <span class="callout-cta">{{ callout.cta }}</span>
             </a>
 
             <label :for="key">{{ formatKey(key) }}</label>
@@ -149,18 +150,7 @@
 <script>
 import axios from 'axios';
 import toml from 'toml-js';
-
-// Where customers sign up for the account a service needs credentials from,
-// keyed by service name. Rendered above the field named by beforeField so the
-// prompt sits with the credentials it belongs to.
-const ACCOUNT_SIGNUPS = {
-  pointperfect: {
-    beforeField: 'ntrip_username',
-    text: 'PointPerfect corrections require a u-blox Thingstream account.',
-    cta: 'Create an account',
-    url: 'https://portal.thingstream.io/register?token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJjdG9rOmYzNGRkMTg2LWNjYWUtNDZhMS1hNWRmLWRiM2UxYjMwZWI5MCIsImF1ZCI6IlRoaW5nc3RyZWFtIiwiY21wIjoicmVkZW1wdGlvbi1jYW1wYWlnbjphZmViMmY4OS05MDMzLTQ1YjAtOGE4NC0wZjBhZGVjMzA3MWUifQ.Y0gn8ai-0eJ7LVs8k1uthvj7LM0WSXhefR70p3l6w6XWBD9mrO99NYdal1NS7wfi1DGyM21TMExaXUnFoxVYSA'
-  }
-};
+import serviceUiHints from './serviceUiHints.js';
 
 export default {
   name: 'TomlEditor',
@@ -178,9 +168,9 @@ export default {
     };
   },
   computed: {
-    // Account signup prompt for this service, if it needs one
-    accountSignup() {
-      return ACCOUNT_SIGNUPS[this.serviceName] || null;
+    // Declarative UI hints for this service (see serviceUiHints.js)
+    uiHints() {
+      return serviceUiHints[this.serviceName] || {};
     },
     // Top-level editable fields (primitives + simple arrays that aren't *_options)
     topLevelFieldKeys() {
@@ -207,6 +197,11 @@ export default {
     this.loadConfig();
   },
   methods: {
+    // Link callouts the hints place above a given top-level field
+    calloutsBefore(key) {
+      return (this.uiHints.callouts || []).filter((c) => c.beforeField === key);
+    },
+
     isObject(value) {
       return typeof value === 'object' && value !== null && !Array.isArray(value);
     },
@@ -468,7 +463,7 @@ h1 {
   color: var(--ark-color-black);
 }
 
-.signup-link {
+.callout-link {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -483,28 +478,28 @@ h1 {
   transition: background-color 0.3s ease;
 }
 
-.signup-link:hover {
+.callout-link:hover {
   background-color: var(--ark-color-white);
 }
 
-.signup-text {
+.callout-text {
   color: var(--ark-color-grey);
   font-size: 14px;
   line-height: 1.4;
 }
 
-.signup-cta {
+.callout-cta {
   color: var(--ark-color-blue);
   font-weight: 600;
   font-size: 14px;
   white-space: nowrap;
 }
 
-.signup-cta::after {
+.callout-cta::after {
   content: ' \2192';
 }
 
-.signup-link:hover .signup-cta {
+.callout-link:hover .callout-cta {
   color: var(--ark-color-blue-hover);
 }
 

--- a/frontend/src/pages/components/TomlEditor.vue
+++ b/frontend/src/pages/components/TomlEditor.vue
@@ -5,9 +5,21 @@
         <h1>{{ serviceName }}</h1>
 
         <div class="toml-editor">
+          <!-- Link callouts from the service's UI hints; no beforeField = top of the form -->
+          <a
+            v-for="callout in calloutsBefore(null)"
+            :key="callout.url"
+            :href="callout.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="callout-link"
+          >
+            <span class="callout-text">{{ callout.text }}</span>
+            <span class="callout-cta">{{ callout.cta }}</span>
+          </a>
+
           <!-- Top-level primitive values first (skip *_options arrays used for dropdowns) -->
           <div v-for="key in topLevelFieldKeys" :key="key" class="form-group">
-            <!-- Link callouts declared in the service's UI hints -->
             <a
               v-for="callout in calloutsBefore(key)"
               :key="callout.url"
@@ -34,7 +46,7 @@
                 :key="option"
                 :value="option"
               >
-                {{ option }}
+                {{ formatValue(option) }}
               </option>
             </select>
 
@@ -94,7 +106,7 @@
                     :key="option"
                     :value="option"
                   >
-                    {{ option }}
+                    {{ formatValue(option) }}
                   </option>
                 </select>
 
@@ -152,6 +164,10 @@ import axios from 'axios';
 import toml from 'toml-js';
 import serviceUiHints from './serviceUiHints.js';
 
+// Display-only casing for tokens the sentence-case default would mangle
+// ("Ntrip host"); config keys and saved values stay lowercase.
+const ACRONYMS = new Set(['ntrip', 'rtcm', 'spartn', 'gga', 'mga', 'tls', 'url', 'api']);
+
 export default {
   name: 'TomlEditor',
   props: {
@@ -197,9 +213,10 @@ export default {
     this.loadConfig();
   },
   methods: {
-    // Link callouts the hints place above a given top-level field
+    // Link callouts for a given slot: a top-level field name, or null for
+    // the top of the form
     calloutsBefore(key) {
-      return (this.uiHints.callouts || []).filter((c) => c.beforeField === key);
+      return (this.uiHints.callouts || []).filter((c) => (c.beforeField || null) === key);
     },
 
     isObject(value) {
@@ -405,8 +422,22 @@ export default {
     },
 
     formatKey(key) {
-      // Capitalize first letter and replace underscores with spaces
-      return key.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase());
+      // Sentence case, with known acronyms uppercased
+      return key
+        .split('_')
+        .map((word, i) => {
+          if (ACRONYMS.has(word)) {
+            return word.toUpperCase();
+          }
+          return i === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word;
+        })
+        .join(' ');
+    },
+
+    // Dropdown option display text; the underlying value is unchanged
+    formatValue(option) {
+      const token = String(option).toLowerCase();
+      return ACRONYMS.has(token) ? token.toUpperCase() : option;
     }
   }
 };

--- a/frontend/src/pages/components/serviceUiHints.js
+++ b/frontend/src/pages/components/serviceUiHints.js
@@ -4,17 +4,16 @@
 // editor. Services without an entry render unchanged.
 //
 // Supported hints:
-//   callouts: [{ beforeField, text, cta, url }]
-//     Link callout rendered above the named top-level field, so a prompt can
-//     sit next to the fields it belongs to (e.g. credentials). The TOML
-//     parser drops comments, so guidance like this can't come from the
-//     config file itself.
+//   callouts: [{ text, cta, url, beforeField? }]
+//     Link callout rendered at the top of the form, or above the named
+//     top-level field when beforeField is set. The TOML parser drops
+//     comments, so guidance like this can't come from the config file
+//     itself.
 
 export default {
   pointperfect: {
     callouts: [
       {
-        beforeField: 'ntrip_username',
         text: 'PointPerfect corrections require a u-blox Thingstream account.',
         cta: 'Create an account',
         url: 'https://portal.thingstream.io/register?token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJjdG9rOmYzNGRkMTg2LWNjYWUtNDZhMS1hNWRmLWRiM2UxYjMwZWI5MCIsImF1ZCI6IlRoaW5nc3RyZWFtIiwiY21wIjoicmVkZW1wdGlvbi1jYW1wYWlnbjphZmViMmY4OS05MDMzLTQ1YjAtOGE4NC0wZjBhZGVjMzA3MWUifQ.Y0gn8ai-0eJ7LVs8k1uthvj7LM0WSXhefR70p3l6w6XWBD9mrO99NYdal1NS7wfi1DGyM21TMExaXUnFoxVYSA'

--- a/frontend/src/pages/components/serviceUiHints.js
+++ b/frontend/src/pages/components/serviceUiHints.js
@@ -1,0 +1,24 @@
+// Per-service UI hints for the generic TomlEditor, keyed by service name.
+// The editor renders whatever hints an entry declares without knowing any
+// service by name — service-specific knowledge belongs here, not in the
+// editor. Services without an entry render unchanged.
+//
+// Supported hints:
+//   callouts: [{ beforeField, text, cta, url }]
+//     Link callout rendered above the named top-level field, so a prompt can
+//     sit next to the fields it belongs to (e.g. credentials). The TOML
+//     parser drops comments, so guidance like this can't come from the
+//     config file itself.
+
+export default {
+  pointperfect: {
+    callouts: [
+      {
+        beforeField: 'ntrip_username',
+        text: 'PointPerfect corrections require a u-blox Thingstream account.',
+        cta: 'Create an account',
+        url: 'https://portal.thingstream.io/register?token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJjdG9rOmYzNGRkMTg2LWNjYWUtNDZhMS1hNWRmLWRiM2UxYjMwZWI5MCIsImF1ZCI6IlRoaW5nc3RyZWFtIiwiY21wIjoicmVkZW1wdGlvbi1jYW1wYWlnbjphZmViMmY4OS05MDMzLTQ1YjAtOGE4NC0wZjBhZGVjMzA3MWUifQ.Y0gn8ai-0eJ7LVs8k1uthvj7LM0WSXhefR70p3l6w6XWBD9mrO99NYdal1NS7wfi1DGyM21TMExaXUnFoxVYSA'
+      }
+    ]
+  }
+};


### PR DESCRIPTION
## Summary

Adds a signup callout to the top of the PointPerfect config editor pointing at the u-blox Thingstream registration page, with the service-specific content declared in a new per-service UI hints module rather than hard-coded in the generic `TomlEditor`. Also fixes acronym casing in the editor's generated labels.

## Problem

Configuring PointPerfect requires NTRIP credentials from a Thingstream account, but the config page gave no indication of where to get one. `toml.parse` drops comments, so guidance in `pointperfect.toml` can never reach the UI — the prompt has to come from the frontend. The first cut embedded a service-name-keyed map inside `TomlEditor.vue`, which would have made the shared editor the accretion point for every future service-specific quirk. Separately, the editor sentence-cases config keys into labels, mangling acronyms ("Ntrip host", "Use tls", and "rtcm" in the format dropdown).

## Solution

`frontend/src/pages/components/serviceUiHints.js` is the declarative home for per-service editor knowledge, keyed by service name. The editor consumes it as data: it gains one generic capability — render link callouts at the top of the form, or above a named field via `beforeField` — and contains no service names, mirroring the existing `*_options` dropdown convention where metadata drives the generic renderer. For PointPerfect, a top-of-form callout links account signup, styled on the existing palette and opening in a new tab. Other services opt in by adding an entry, and the same manifest is the natural home for future per-field metadata (help text, password masking, units) without touching the editor per service.

Label generation now uppercases known acronyms (NTRIP, RTCM, SPARTN, GGA, MGA, TLS, URL, API): "NTRIP host", "Use TLS", "Connection URL". Dropdown options get the same display treatment ("RTCM") while the stored value stays lowercase, so saved configs are unchanged.

Note for reviewers: the registration URL embeds a redemption-campaign token, so merging bakes it into releases and git history. Worth confirming the campaign has no redemption cap or expiry that would outlive a shipped release — a vanity redirect under ARK's control would be easier to rotate. Keeping the URL in the frontend bundle rather than the on-device TOML at least means an OS update can replace it.
