### PR TITLE
feat(modalix): ARK-OS package for SiMa Modalix / eLxr (JAJ)

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -39,6 +39,15 @@ jobs:
             runner: ubuntu-22.04-arm
             container: "debian:trixie"
             extra_deps: ""
+          # Modalix eLxr 12 (aria) is Debian 12 / Python 3.11 class. No public eLxr
+          # container on GH runners yet — build in debian:bookworm and name the
+          # package ark-os-modalix-bookworm for install testing; prefer a native
+          # aarch64 eLxr 12 host for ark-os-modalix-aria release builds.
+          - platform: modalix
+            codename: bookworm
+            runner: ubuntu-22.04-arm
+            container: "debian:bookworm"
+            extra_deps: ""
     # Build each platform on a host whose OS matches the target so the bundled venv
     # and natively-compiled binaries are ABI-compatible. The venv is created with
     # `python3 -m venv --copies`, which ships the interpreter but resolves the stdlib
@@ -47,6 +56,7 @@ jobs:
     #   - jetson: ubuntu-22.04-arm natively    (Jammy / Python 3.10  = JetPack 6 rootfs)
     #   - pi:     a debian:bookworm container  (Debian 12 / Python 3.11 = Raspberry Pi OS Bookworm)
     #   - pi:     a debian:trixie   container  (Debian 13 / Python 3.13 = Raspberry Pi OS Trixie)
+    #   - modalix: debian:bookworm container   (Python 3.11 ≈ eLxr 12 / aria)
     # The container runs on the same arm64 host. Each leg's `codename` (the host's OS
     # release) is part of the package name (ark-os-<platform>-<codename>); supporting a
     # new release is one more leg here plus an entry in build.sh's BASELINES table.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ ARK-OS is a collection of software services and tools for drones. These services
 
 #### Supported targets
 - **ARK Jetson PAB Carrier / PAB Carrier V3** <br> https://arkelectron.com/product/ark-jetson-pab-carrier/
-- **ARK Just a Jetson** <br> https://arkelectron.com/product/ark-just-a-jetson/
+- **ARK Just a Jetson** (Jetson Orin NX/Nano) <br> https://arkelectron.com/product/ark-just-a-jetson/
+- **ARK Just a Jetson + SiMa Modalix SoM** (eLxr) — platform `modalix` (see `platform/modalix/README.md`)
 - **ARK Pi6X Flow** <br> https://arkelectron.com/product/ark-pi6x-flow/
 - **ARK Just a Pi** <br> https://arkelectron.com/product/ark-just-a-pi/
 
@@ -17,6 +18,7 @@ ssh <user>@<hostname>.local
 |--------|----------|----------|
 | jetson | jetson   | jetson   |
 | pi     | pi       | pi6x     |
+| sima   | edgeai   | modalix (SiMa eLxr / JAJ+Modalix) |
 
 Connect to your WiFi network using Network Manager
 ```
@@ -57,6 +59,17 @@ sudo apt install ./ark-os-jetson-jammy_<ark-os-ver>_arm64.deb
 # Recommended: jtop, for Jetson system stats in the web UI
 sudo apt install -y python3-pip && sudo pip3 install "jetson-stats==<jetson-stats-ver>"
 ```
+
+#### Modalix (SiMa eLxr 12 / ARK JAJ + Modalix)
+Flash the SiMa eLxr base image first (see meta-ark-simaai bring-up), then install the
+`modalix` package as user **`sima`**. No jetson-stats. Build on arm64 Debian 12 or eLxr 12:
+
+```
+./packaging/build.sh modalix --version=X.Y.Z
+sudo ./packaging/install_ark_os.sh --platform=modalix ./ark-os-modalix-bookworm_X.Y.Z_arm64.deb
+```
+
+Details: [`platform/modalix/README.md`](platform/modalix/README.md).
 
 #### Raspberry Pi
 Identical, replacing `ark-os-jetson-jammy` with `ark-os-pi-trixie` for Raspberry Pi OS Trixie (Debian 13) — use `ark-os-pi-bookworm` on Debian 12. No jetson-stats step:

--- a/frontend/src/pages/SystemPage.vue
+++ b/frontend/src/pages/SystemPage.vue
@@ -88,17 +88,24 @@
                 </div>
               </div>
 
-              <div class="memory-item">
+              <div
+                v-for="(disk, idx) in diskVolumes"
+                :key="disk.device || idx"
+                class="memory-item"
+              >
                 <ProgressBar
-                  label="Disk"
-                  :value="diskPercent"
+                  :label="diskLabel(disk)"
+                  :value="disk.percent || 0"
                   :showPercentage="true"
                   :warningThreshold="80"
                   :criticalThreshold="90"
                 />
                 <div class="memory-info">
-                  <span>{{ formatDiskSize(diskTotal) }} Total</span>
-                  <span>{{ formatDiskSize(diskAvailable) }} Available</span>
+                  <span>{{ formatDiskSize(disk.total) }} Total</span>
+                  <span v-if="disk.mountpoint">
+                    {{ formatDiskSize(disk.available) }} Available
+                  </span>
+                  <span v-else class="disk-unmounted">Not mounted</span>
                 </div>
               </div>
             </div>
@@ -333,6 +340,28 @@ export default {
     diskAvailable() {
       const disk = this.systemInfo?.resources?.disk || this.systemInfo?.disk;
       return disk?.available || 0;
+    },
+
+    /** All physical disks (eMMC + NVMe etc.); fall back to root-only disk field. */
+    diskVolumes() {
+      const disks = this.systemInfo?.resources?.disks;
+      if (Array.isArray(disks) && disks.length > 0) {
+        return disks;
+      }
+      const disk = this.systemInfo?.resources?.disk || this.systemInfo?.disk;
+      if (!disk) return [];
+      return [
+        {
+          name: 'Disk',
+          device: '/',
+          mountpoint: '/',
+          total: disk.total || 0,
+          used: disk.used || 0,
+          available: disk.available || 0,
+          percent: disk.percent || 0,
+          model: ''
+        }
+      ];
     }
   },
 
@@ -438,7 +467,16 @@ export default {
 
     formatDiskSize(sizeInGB) {
       if (!sizeInGB) return '0 GB';
+      if (sizeInGB >= 100) return `${sizeInGB.toFixed(0)} GB`;
       return `${sizeInGB.toFixed(1)} GB`;
+    },
+
+    diskLabel(disk) {
+      if (!disk) return 'Disk';
+      const name = disk.name || disk.device || 'Disk';
+      if (disk.mountpoint === '/') return `${name} (/)`;
+      if (disk.mountpoint) return `${name} (${disk.mountpoint})`;
+      return name;
     }
   }
 }
@@ -552,6 +590,11 @@ export default {
 
 .memory-info span:first-child {
   font-weight: 500;
+}
+
+.disk-unmounted {
+  font-style: italic;
+  color: #999;
 }
 
 .temp-scroll-container {

--- a/frontend/src/pages/SystemPage.vue
+++ b/frontend/src/pages/SystemPage.vue
@@ -213,6 +213,13 @@ export default {
         data['Power Mode'] = power?.nvpmodel || 'Not available';
         data['Jetson Clocks'] = power?.jetson_clocks || 'Not available';
       }
+      // Rail voltage / current when provided (Modalix INA238)
+      if (power?.voltage != null && Number(power.voltage) > 0) {
+        data['Voltage'] = `${Number(power.voltage).toFixed(2)} V`;
+      }
+      if (power?.current != null && Number.isFinite(Number(power.current))) {
+        data['Current'] = `${Number(power.current).toFixed(3)} A`;
+      }
       // Jetson jtop and Modalix INA238 both use power.total in milliwatts
       data['Power Draw'] =
         power?.total && power.total > 0

--- a/frontend/src/pages/SystemPage.vue
+++ b/frontend/src/pages/SystemPage.vue
@@ -33,8 +33,9 @@
           :data="platformData"
         />
 
-        <!-- Libraries Card -->
+        <!-- Libraries Card (Jetson NVIDIA stack only) -->
         <SystemCard
+          v-if="showLibrariesCard"
           title="Libraries"
           icon="fa-book"
           :data="librariesData"
@@ -145,17 +146,34 @@ export default {
              'Unknown';
     },
 
+    deviceType() {
+      return this.systemInfo?.device_type || 'generic';
+    },
+
+    isJetson() {
+      return this.deviceType === 'jetson';
+    },
+
+    showLibrariesCard() {
+      // NVIDIA CUDA stack is Jetson-only; hide empty "Not available" wall on Modalix/Pi
+      return this.isJetson;
+    },
+
     hardwareData() {
       const hw = this.systemInfo?.hardware;
       if (!hw) return { 'Status': 'Data unavailable' };
 
-      return {
+      const data = {
         'Model': hw.model || 'Not available',
         'Module': hw.module || 'Not available',
-        'Serial': hw.serial_number || 'Not available',
-        'L4T': hw.l4t || 'Not available',
-        'JetPack': hw.jetpack || 'Not available'
+        'Serial': hw.serial_number || 'Not available'
       };
+      // L4T / JetPack only on real Jetson
+      if (this.isJetson) {
+        data['L4T'] = hw.l4t || 'Not available';
+        data['JetPack'] = hw.jetpack || 'Not available';
+      }
+      return data;
     },
 
     platformData() {
@@ -173,8 +191,9 @@ export default {
 
     librariesData() {
       const libs = this.systemInfo?.libraries;
-
-      // Always show these fields, even if not available
+      if (!this.isJetson) {
+        return {};
+      }
       return {
         'CUDA': libs?.cuda || 'Not available',
         'OpenCV': libs?.opencv || 'Not available',
@@ -190,19 +209,25 @@ export default {
       const data = {};
       const power = this.systemInfo?.power;
 
-      // Power information (primarily for Jetson)
-      data['Power Mode'] = power?.nvpmodel || 'Not available';
-      data['Jetson Clocks'] = power?.jetson_clocks || 'Not available';
-      data['Power Draw'] = power?.total ? `${(power.total / 1000).toFixed(2)} W` : 'Not available';
+      if (this.isJetson) {
+        data['Power Mode'] = power?.nvpmodel || 'Not available';
+        data['Jetson Clocks'] = power?.jetson_clocks || 'Not available';
+      }
+      // Jetson jtop and Modalix INA238 both use power.total in milliwatts
+      data['Power Draw'] =
+        power?.total && power.total > 0
+          ? `${(power.total / 1000).toFixed(2)} W`
+          : 'Not available';
 
-      // Primary temperatures
-      const temps = this.systemInfo?.temperature || power?.temperature;
-      if (temps) {
+      // Primary temperatures (Jetson has cpu/gpu; Modalix may have ina238 die temp)
+      const temps = this.systemInfo?.temperature || power?.temperature || {};
+      if (this.isJetson) {
         data['CPU Temp'] = temps.cpu ? `${temps.cpu.toFixed(1)}°C` : 'Not available';
         data['GPU Temp'] = temps.gpu ? `${temps.gpu.toFixed(1)}°C` : 'Not available';
-      } else {
-        data['CPU Temp'] = 'Not available';
-        data['GPU Temp'] = 'Not available';
+      } else if (temps.ina238 != null) {
+        data['PMIC Temp'] = `${Number(temps.ina238).toFixed(1)}°C`;
+      } else if (temps.cpu != null) {
+        data['CPU Temp'] = `${Number(temps.cpu).toFixed(1)}°C`;
       }
 
       return data;

--- a/packaging/DEBIAN/control
+++ b/packaging/DEBIAN/control
@@ -12,4 +12,4 @@ Description: ARK-OS companion computer platform
  Pre-compiled services, web UI, and system configuration for autonomous vehicles.
  .
  The @PLATFORM@ package installs system-level systemd units that run as the
- default platform user. The Pi package assumes the default "pi" user exists.
+ default platform user (jetson / pi / sima for modalix).

--- a/packaging/DEBIAN/postinst
+++ b/packaging/DEBIAN/postinst
@@ -29,11 +29,7 @@ MIGRATED=0
 
 # ===========================================================================
 # Required service account. Every ARK-OS unit runs as User=$ARK_USER (baked at
-# build time: 'jetson' or 'pi'). Modern Raspberry Pi OS no longer ships a default
-# 'pi' account — it is chosen at imaging time — so a Pi imaged with a different
-# username has no 'pi' user and every service would fail to start. Fail early with
-# guidance instead of letting the Step 1 usermod abort with a cryptic error.
-# (Jetson chroot provisioning creates the 'jetson' user before this runs.)
+# build time: jetson, pi, or sima for modalix/eLxr). Fail early with guidance.
 # ===========================================================================
 if ! getent passwd "$ARK_USER" >/dev/null; then
     echo "ERROR: ARK-OS requires a user named '$ARK_USER', which does not exist on this system." >&2
@@ -41,6 +37,7 @@ if ! getent passwd "$ARK_USER" >/dev/null; then
     echo "       '$ARK_USER', or create the account and reinstall:" >&2
     echo "         sudo useradd -m -s /bin/bash $ARK_USER && sudo passwd $ARK_USER" >&2
     echo "         sudo usermod -aG sudo $ARK_USER" >&2
+    echo "       Modalix eLxr images use 'sima' by default." >&2
     exit 1
 fi
 

--- a/packaging/DEBIAN/preinst
+++ b/packaging/DEBIAN/preinst
@@ -13,7 +13,17 @@ want="@CODENAME@"
 have=""
 [ -r /etc/os-release ] && have="$(. /etc/os-release && printf '%s' "${VERSION_CODENAME:-}")"
 
-if [ -n "$have" ] && [ "$have" != "$want" ]; then
+# Modalix: eLxr 12 (aria) is Debian 12 / Python 3.11 class, same as bookworm CI builds.
+compatible_codename=0
+if [ "$have" = "$want" ]; then
+    compatible_codename=1
+elif [ "@PLATFORM@" = "modalix" ] && { [ "$want" = "bookworm" ] && [ "$have" = "aria" ]; }; then
+    compatible_codename=1
+elif [ "@PLATFORM@" = "modalix" ] && { [ "$want" = "aria" ] && [ "$have" = "bookworm" ]; }; then
+    compatible_codename=1
+fi
+
+if [ -n "$have" ] && [ "$compatible_codename" -eq 0 ]; then
     echo "ERROR: ark-os-@PLATFORM@-$want is built for the '$want' OS release, but this system is '$have'." >&2
     echo "       Its bundled runtime will not work here — install the ark-os-@PLATFORM@-$have build instead." >&2
     if [ "${ARK_OS_ALLOW_CODENAME_MISMATCH:-0}" != "1" ]; then

--- a/packaging/assemble_tree.sh
+++ b/packaging/assemble_tree.sh
@@ -18,8 +18,10 @@ ARK="$PKG_PREFIX"   # /usr/lib/ark-os
 # Trixie's time64 transition renamed libssl3 -> libssl3t64, handled in control by the
 # alternative "libssl3t64 | libssl3"; use the same idiom if a future release renames more.
 case "$P" in
-    jetson) EXTRA_DEPENDS=", bluez, bluez-tools, libbluetooth3, libqmi-utils" ;;
-    pi)     EXTRA_DEPENDS=", gstreamer1.0-libcamera, raspi-utils" ;;
+    jetson)  EXTRA_DEPENDS=", bluez, bluez-tools, libbluetooth3, libqmi-utils" ;;
+    pi)      EXTRA_DEPENDS=", gstreamer1.0-libcamera, raspi-utils" ;;
+    # eLxr/Modalix: base gstreamer deps only; no Jetson BT QMI stack, no raspi-utils.
+    modalix) EXTRA_DEPENDS="" ;;
 esac
 
 # --- directory skeleton ---
@@ -111,8 +113,10 @@ mkdir -p "$DEFAULTS"
 install -m 0644 services/mavlink-router/main.conf "$DEFAULTS/mavlink-router.conf"
 for f in packaging/config/*; do
     base=$(basename "$f")
-    # rid-transmitter is jetson-only; skip its config on pi.
-    [ "$P" = "pi" ] && [ "$base" = "rid-transmitter.toml" ] && continue
+    # rid-transmitter is jetson-only; skip on pi and modalix.
+    if { [ "$P" = "pi" ] || [ "$P" = "modalix" ]; } && [ "$base" = "rid-transmitter.toml" ]; then
+        continue
+    fi
     install -m 0644 "$f" "$DEFAULTS/$base"
 done
 install -m 0755 packaging/system-config/merge_configs.py "$PKG$ARK/libexec/merge_configs.py"
@@ -131,7 +135,8 @@ install -m 0644 platform/common/wifi/99-network.pkla \
 
 # --- service-manager polkit rule: substitute @ARK_USER@; pi strips JETSON-ONLY ---
 SMR="$PKG/etc/polkit-1/rules.d/03-ark-service-manager.rules"
-if [ "$P" = "pi" ]; then
+if [ "$P" = "pi" ] || [ "$P" = "modalix" ]; then
+    # No Jetson-only polkit grants (jtop etc.) on Pi or Modalix.
     sed "s/@ARK_USER@/$ARK_USER/g" packaging/system-config/03-ark-service-manager.rules \
         | grep -v 'JETSON-ONLY' > "$SMR"
 else

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # Master build orchestrator for the ARK-OS .deb.
 #
-# Usage: ./packaging/build.sh <jetson|pi> [--version=X.Y.Z]
+# Usage: ./packaging/build.sh <jetson|pi|modalix> [--version=X.Y.Z]
 #
 # Must run on arm64 (native compilation, arm64 venv, arm64 Node). Produces
 # ark-os-<platform>-<codename>_<version>_arm64.deb in the repo root; <codename> is
 # read from the build host's OS release. The helper scripts read the exported
 # environment below; run them via this orchestrator, not directly.
+#
+# modalix: SiMa Modalix SoM on eLxr 12 (aria) / ARK Just a Jetson. Service user
+# is 'sima' (SiMa eLxr default), not 'modalix'. Build on aarch64 eLxr 12 or a
+# bookworm host with ARK_OS_ALLOW_HOST_MISMATCH only for packaging dry-runs.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -31,8 +35,8 @@ for arg in "$@"; do
 done
 
 case "$PLATFORM" in
-    jetson|pi) ;;
-    *) echo "Usage: $0 <jetson|pi> [--version=X.Y.Z]" >&2; exit 1 ;;
+    jetson|pi|modalix) ;;
+    *) echo "Usage: $0 <jetson|pi|modalix> [--version=X.Y.Z]" >&2; exit 1 ;;
 esac
 
 if [ -z "$VERSION" ]; then
@@ -41,7 +45,11 @@ if [ -z "$VERSION" ]; then
 fi
 
 export PLATFORM VERSION REPO_ROOT
-export ARK_USER="$PLATFORM"          # the service user matches the platform name
+# Service account: jetson/pi match the platform name; Modalix eLxr ships 'sima'.
+case "$PLATFORM" in
+    modalix) export ARK_USER="sima" ;;
+    *)       export ARK_USER="$PLATFORM" ;;
+esac
 export PKG_PREFIX="/usr/lib/ark-os"  # install prefix inside the package
 export BUILD_DIR="$REPO_ROOT/build/ark-os-$PLATFORM"
 
@@ -68,8 +76,10 @@ fi
 # new OS release = add an entry here and a matching leg to the CI build matrix
 # (.github/workflows/build-deb.yml).
 case "$PLATFORM" in
-    jetson) BASELINES="jammy:3.10 noble:3.12" ;;     # JetPack 6 / JetPack 7 (noble = future, untested)
-    pi)     BASELINES="bookworm:3.11 trixie:3.13" ;;  # Debian 12 (Pi OS Bookworm) / Debian 13 (Pi OS Trixie)
+    jetson)  BASELINES="jammy:3.10 noble:3.12" ;;     # JetPack 6 / JetPack 7 (noble = future, untested)
+    pi)      BASELINES="bookworm:3.11 trixie:3.13" ;;  # Debian 12 (Pi OS Bookworm) / Debian 13 (Pi OS Trixie)
+    # eLxr 12 (aria) is Debian 12-based with Python 3.11 — same ABI class as bookworm.
+    modalix) BASELINES="aria:3.11 bookworm:3.11" ;;
 esac
 
 HOST_CODENAME=""

--- a/packaging/build_venv.sh
+++ b/packaging/build_venv.sh
@@ -32,6 +32,10 @@ echo "==> flight-review requirements"
 # the jtop client is unavailable.
 if [ "$PLATFORM" = "jetson" ]; then
     "$VENV/bin/pip" install "Jetson.GPIO>=2.1.12" smbus2
+elif [ "$PLATFORM" = "modalix" ]; then
+    # No Jetson.GPIO. smbus2 optional for diagnostics; board power uses
+    # meta-ark-simaai ark-jaj-sys-power when installed on the image.
+    "$VENV/bin/pip" install smbus2
 elif [ "$PLATFORM" = "pi" ]; then
     # No Python GPIO library is installed for Pi. The vbus_*/reset_fmu_* helpers
     # drive GPIO via the system `pinctrl` tool (raspi-utils) instead. Classic

--- a/packaging/install_ark_os.sh
+++ b/packaging/install_ark_os.sh
@@ -180,8 +180,13 @@ info "Platform: $PLATFORM"
 # Every ARK-OS service runs as User=$PLATFORM (baked into the unit files). Modern
 # Raspberry Pi OS no longer ships a default 'pi' account, so fail before touching
 # the system rather than letting the deb's postinst abort on a missing user.
-getent passwd "$PLATFORM" >/dev/null 2>&1 || \
-    die "ARK-OS services run as the user '$PLATFORM', which does not exist on this device. Re-image with the username '$PLATFORM', or create it first: sudo useradd -m -s /bin/bash $PLATFORM && sudo passwd $PLATFORM && sudo usermod -aG sudo $PLATFORM"
+# Service account matches platform for jetson/pi; Modalix eLxr uses 'sima'.
+case "$PLATFORM" in
+    modalix) SERVICE_USER=sima ;;
+    *)       SERVICE_USER=$PLATFORM ;;
+esac
+getent passwd "$SERVICE_USER" >/dev/null 2>&1 || \
+    die "ARK-OS services run as the user '$SERVICE_USER', which does not exist on this device. Re-image with the username '$SERVICE_USER', or create it first: sudo useradd -m -s /bin/bash $SERVICE_USER && sudo passwd $SERVICE_USER && sudo usermod -aG sudo $SERVICE_USER"
 
 # --- Scratch space for downloads ---
 DL_DIR="$(mktemp -d)"

--- a/packaging/install_ark_os.sh
+++ b/packaging/install_ark_os.sh
@@ -51,7 +51,7 @@ Positional:
                             --ark-os-version is given.
 
 Options:
-  --platform=jetson|pi      Override platform autodetection.
+  --platform=jetson|pi|modalix  Override platform autodetection.
   --codename=NAME           Override OS-release codename autodetection (bookworm, trixie,
                             jammy, …). Only needed to name a download when /etc/os-release
                             can't be read.
@@ -99,19 +99,30 @@ JETSON_STATS_VERSION="${OPT_JETSON_STATS_VERSION:-${JETSON_STATS_VERSION:-}}"
 # --- Helpers ---
 platform_from_deb() {
     case "$(basename "$1")" in
-        ark-os-jetson-*) echo jetson ;;
-        ark-os-pi-*)     echo pi ;;
+        ark-os-jetson-*)  echo jetson ;;
+        ark-os-pi-*)      echo pi ;;
+        ark-os-modalix-*) echo modalix ;;
         *)               return 1 ;;
     esac
 }
 
 detect_platform() {
     [ -f /etc/nv_tegra_release ] && { echo jetson; return; }
+    # SiMa eLxr on Modalix (ARK Just a Jetson + Modalix SoM, etc.)
+    if [ -r /etc/os-release ]; then
+        # shellcheck source=/dev/null
+        . /etc/os-release
+        if [ "${ID:-}" = "elxr" ] || [ "${ID_LIKE:-}" = *"elxr"* ]; then
+            echo modalix
+            return
+        fi
+    fi
     if [ -r /proc/device-tree/model ]; then
         local model; model="$(tr -d '\0' < /proc/device-tree/model)"
         case "$model" in
             *Jetson*|*Tegra*) echo jetson; return ;;
             *Raspberry*Pi*)   echo pi;     return ;;
+            *Modalix*|*modalix*|*Just\ a\ Jetson*) echo modalix; return ;;
         esac
     fi
     return 1
@@ -156,8 +167,8 @@ if [ -z "$PLATFORM" ] && [ -n "$DEB_ARG" ]; then
     PLATFORM="$(platform_from_deb "$DEB_ARG" || true)"
 fi
 [ -n "$PLATFORM" ] || PLATFORM="$(detect_platform || true)"
-[ -n "$PLATFORM" ] || die "could not determine platform; pass --platform=jetson|pi."
-case "$PLATFORM" in jetson|pi) ;; *) die "invalid platform '$PLATFORM' (expected jetson or pi)." ;; esac
+[ -n "$PLATFORM" ] || die "could not determine platform; pass --platform=jetson|pi|modalix."
+case "$PLATFORM" in jetson|pi|modalix) ;; *) die "invalid platform '$PLATFORM' (expected jetson|pi|modalix)." ;; esac
 info "Platform: $PLATFORM"
 
 # Codename: explicit flag wins; otherwise read from the device's /etc/os-release.

--- a/packaging/service-files/modalix/ark-ui-backend.service
+++ b/packaging/service-files/modalix/ark-ui-backend.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=ARK UI Backend Service
+Wants=network-online.target
+After=network-online.target nginx.service
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+WorkingDirectory=/usr/lib/ark-os/ark-ui-backend
+ExecStart=/usr/lib/ark-os/bin/node /usr/lib/ark-os/ark-ui-backend/index.js
+Restart=on-failure
+Environment=NODE_ENV=production
+Environment=PATH=/usr/lib/ark-os/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/autopilot-manager.service
+++ b/packaging/service-files/modalix/autopilot-manager.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Microservice backend for autopilot mavlink interactions
+Wants=network.target network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+ExecStart=/usr/lib/ark-os/venv/bin/python3 /usr/lib/ark-os/python/autopilot_manager.py
+Restart=on-failure
+RestartSec=5
+Environment=PYTHONUNBUFFERED=1
+Environment=PORT=3003
+# clock_settime: adopt the FC's GNSS time when the local clock has no NTP sync.
+AmbientCapabilities=CAP_SYS_TIME
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/connection-manager.service
+++ b/packaging/service-files/modalix/connection-manager.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Manages network connections via NetworkManager using Python and nmcli
+Wants=network.target network-online.target NetworkManager.service
+After=network-online.target NetworkManager.service
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+ExecStart=/usr/lib/ark-os/venv/bin/python3 /usr/lib/ark-os/python/connection_manager.py
+Restart=on-failure
+RestartSec=5
+Environment=PYTHONUNBUFFERED=1
+Environment=PORT=3001
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/dds-agent.service
+++ b/packaging/service-files/modalix/dds-agent.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Micro-XRCE-DDS-Agent
+Wants=network.target
+After=dev-ttyTHS1.device dev-ttyAMA4.device network-online.target
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+ExecStart=/usr/lib/ark-os/libexec/start_dds_agent.sh
+Restart=on-failure
+RestartSec=5
+ExecStartPre=/bin/sleep 2
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/flight-review.service
+++ b/packaging/service-files/modalix/flight-review.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=PX4 Flight Review
+Wants=network.target
+After=network-online.target nginx.service
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+ExecStart=/usr/lib/ark-os/libexec/start_flight_review.sh
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/go2rtc.service
+++ b/packaging/service-files/modalix/go2rtc.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=go2rtc WebRTC gateway
+Wants=network.target
+After=network-online.target rtsp-server.service
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+ExecStart=/usr/lib/ark-os/bin/go2rtc -config /etc/ark-os/go2rtc.yaml
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/logloader.service
+++ b/packaging/service-files/modalix/logloader.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Automatic ulog download and upload
+Wants=network.target
+After=network.target mavlink-router.service
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+Environment=SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ExecStart=/usr/lib/ark-os/bin/logloader --config /etc/ark-os/logloader.toml
+Restart=always
+RestartSec=5
+Nice=10
+CPUWeight=50
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/mavlink-router.service
+++ b/packaging/service-files/modalix/mavlink-router.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Mavlink Router
+Wants=network.target
+After=network-online.target
+# Cap the no-FC crash-loop: 5 failed starts within 60s fail the unit permanently
+# (until reset-failed/reboot); a re-plug within the window still recovers in ~5s.
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=exec
+User=sima
+Group=sima
+ExecStart=/usr/lib/ark-os/libexec/start_mavlink_router.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/pointperfect.service
+++ b/packaging/service-files/modalix/pointperfect.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=u-blox PointPerfect GNSS corrections client for MAVLink
+Wants=network.target
+After=network-online.target mavlink-router.service
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+ExecStart=/usr/lib/ark-os/bin/pointperfect-client-mavlink --config /etc/ark-os/pointperfect.toml
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/polaris.service
+++ b/packaging/service-files/modalix/polaris.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Polaris GNSS corrections service client for MAVLink
+Wants=network.target
+After=network-online.target mavlink-router.service
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+ExecStart=/usr/lib/ark-os/bin/polaris-client-mavlink --config /etc/ark-os/polaris.toml
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/rtsp-server.service
+++ b/packaging/service-files/modalix/rtsp-server.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=RTSP Server
+Wants=network.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+ExecStart=/usr/lib/ark-os/bin/rtsp-server --config /etc/ark-os/rtsp-server.toml
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/service-manager.service
+++ b/packaging/service-files/modalix/service-manager.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Microservice backend for managing systemd services
+Wants=network.target network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+ExecStart=/usr/lib/ark-os/venv/bin/python3 /usr/lib/ark-os/python/service_manager.py
+Restart=on-failure
+RestartSec=5
+Environment=PYTHONUNBUFFERED=1
+Environment=PORT=3002
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/packaging/service-files/modalix/system-manager.service
+++ b/packaging/service-files/modalix/system-manager.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Microservice backend for monitoring and managing the linux system
+Wants=network.target network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=sima
+Group=sima
+ExecStart=/usr/lib/ark-os/venv/bin/python3 /usr/lib/ark-os/python/system_manager.py
+Restart=on-failure
+RestartSec=5
+Environment=PYTHONUNBUFFERED=1
+Environment=PORT=3004
+
+[Install]
+WantedBy=multi-user.target ark-os.target

--- a/platform/modalix/README.md
+++ b/platform/modalix/README.md
@@ -1,0 +1,60 @@
+# Modalix platform (SiMa eLxr + ARK JAJ)
+
+ARK-OS as a **Debian package** for SiMa **Modalix** SoM running **eLxr 12 (aria)** —
+typically **ARK Just a Jetson** with Modalix.
+
+## Not a full OS flash
+
+ARK-OS does **not** replace the SiMa base image. Order of operations:
+
+1. Flash / netboot **SiMa Modalix eLxr** (see [meta-ark-simaai](https://github.com/ARK-Electronics/meta-ark-simaai)
+   `docs/bringup-jaj.md`, `deploy-jaj-dtbo.sh`).
+2. Deploy `ark-jaj.dtbo` (cameras, I2C, UART, INA238 DT nodes).
+3. Build/install **`ark-os-modalix-<codename>_*.deb`** on the board.
+
+## Build
+
+```bash
+# On aarch64 with Debian 12/bookworm or eLxr 12/aria (Python 3.11):
+./packaging/build.sh modalix --version=0.0.0-modalix
+
+# On x86_64 workstations the arm64 binaries/venv will not run on the SoM.
+# Use CI (ubuntu-22.04-arm + debian:bookworm) or an arm64 builder.
+```
+
+Package name examples:
+
+- `ark-os-modalix-bookworm_*_arm64.deb` — CI / Debian 12 builders  
+- `ark-os-modalix-aria_*_arm64.deb` — native eLxr 12 builders  
+
+`preinst` treats **aria ↔ bookworm** as compatible for modalix only.
+
+## Install on the SoM
+
+```bash
+# as root on the device (user must be sima — SiMa default)
+sudo ./packaging/install_ark_os.sh --platform=modalix ./ark-os-modalix-bookworm_*.deb
+# or:
+sudo ./packaging/install_ark_os.sh --platform=modalix --ark-os-version=X.Y.Z
+```
+
+- **Service user:** `sima` (not `jetson` / not `modalix`)  
+- **No jtop** (Jetson-stats)  
+- **No jetson-can** (Modalix has no SoM CAN)  
+- **No rid-transmitter** in the first cut  
+- **FMU reset / VBUS GPIO helpers** are no-ops until JAJ nRESET is mapped  
+
+## Autopilot link
+
+mavlink-router still prefers `/dev/serial/by-id/*ARK*if00` (USB FC). That path is
+the same as Jetson when the flight controller is USB.
+
+## Board power / unique ID
+
+Prefer meta-ark-simaai’s `ark-jaj-sys-power` (INA238 + AT24CSW010 on I2C1) when that
+image layer is present:
+
+```bash
+cat /run/ark-jaj/sys-power/voltage_uV
+cat /run/ark-jaj/board/unique_id
+```

--- a/platform/modalix/scripts/reset_fmu_fast.py
+++ b/platform/modalix/scripts/reset_fmu_fast.py
@@ -1,0 +1,17 @@
+#!/usr/lib/ark-os/venv/bin/python3
+"""Modalix / JAJ: FMU nRESET is not mapped like Jetson BOARD pin 33 yet.
+
+USB bootloader entry still works if the FC exposes the ARK CDC interface.
+This helper exits 0 so call sites do not hard-fail; operators can use a
+hardware reset or map a Modalix GPIO later.
+"""
+import sys
+
+
+def main() -> int:
+    print("Modalix: reset_fmu_fast is a no-op until nRESET GPIO is mapped")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/platform/modalix/scripts/reset_fmu_wait_bl.py
+++ b/platform/modalix/scripts/reset_fmu_wait_bl.py
@@ -1,0 +1,16 @@
+#!/usr/lib/ark-os/venv/bin/python3
+"""Modalix / JAJ: FMU nRESET not mapped like Jetson. No-op success.
+
+Prefer USB bootloader mode (hold boot button) when flashing until a
+Modalix GPIO reset path is implemented.
+"""
+import sys
+
+
+def main() -> int:
+    print("Modalix: reset_fmu_wait_bl is a no-op until nRESET GPIO is mapped")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/platform/modalix/scripts/vbus_disable.py
+++ b/platform/modalix/scripts/vbus_disable.py
@@ -1,0 +1,12 @@
+#!/usr/lib/ark-os/venv/bin/python3
+"""Modalix / JAJ: VBUS detect is not Jetson-board-GPIO-driven. No-op."""
+import sys
+
+
+def main() -> int:
+    print("Modalix: vbus_disable is a no-op (no Jetson VBUS GPIO path)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/platform/modalix/scripts/vbus_enable.py
+++ b/platform/modalix/scripts/vbus_enable.py
@@ -1,0 +1,16 @@
+#!/usr/lib/ark-os/venv/bin/python3
+"""Modalix / JAJ: VBUS detect is a SoM hog (input), not a Jetson board pin.
+
+FC flashing over USB does not need the Jetson VBUS GPIO dance. This is a
+no-op so mavlink-router / flash helpers stay callable on Modalix.
+"""
+import sys
+
+
+def main() -> int:
+    print("Modalix: vbus_enable is a no-op (no Jetson VBUS GPIO path)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/system-manager/system_manager.py
+++ b/services/system-manager/system_manager.py
@@ -58,6 +58,9 @@ class Power(BaseModel):
     jetson_clocks: str | None
     total: float
     temperature: dict[str, float] = Field(default_factory=dict)
+    # Optional rail measurements (Modalix INA238); volts / amps when known
+    voltage: float | None = None
+    current: float | None = None
 
 
 class Usage(BaseModel):
@@ -554,28 +557,54 @@ class ModalixCollector(SystemInfoCollector):
         # Power: /run/ark-jaj/sys-power from INA238 userspace (or future hwmon)
         # Frontend expects power.total in milliwatts (Jetson jtop convention).
         power_total_mw = 0.0
-        power_uW = cls._read_file(f"{cls._POWER_DIR}/power_uW")
-        if power_uW and power_uW.lstrip("-").isdigit():
-            power_total_mw = float(power_uW) / 1000.0
-        else:
-            # Fallback: try in-kernel hwmon ina238 if present
+        voltage_V: float | None = None
+        current_A: float | None = None
+
+        def _num(s: str | None) -> float | None:
+            if s is None:
+                return None
+            s = s.strip()
+            try:
+                return float(s)
+            except ValueError:
+                return None
+
+        power_uW = _num(cls._read_file(f"{cls._POWER_DIR}/power_uW"))
+        voltage_uV = _num(cls._read_file(f"{cls._POWER_DIR}/voltage_uV"))
+        current_uA = _num(cls._read_file(f"{cls._POWER_DIR}/current_uA"))
+        if power_uW is not None:
+            power_total_mw = power_uW / 1000.0
+        if voltage_uV is not None:
+            voltage_V = voltage_uV / 1e6
+        if current_uA is not None:
+            current_A = current_uA / 1e6
+
+        if power_uW is None and voltage_V is None:
+            # Fallback: in-kernel hwmon ina238 (power1 µW, in1 mV, curr1 mA)
             try:
                 for name in os.listdir("/sys/class/hwmon"):
                     base = f"/sys/class/hwmon/{name}"
-                    hwname = cls._read_file(f"{base}/name") or ""
-                    if hwname.lower() in ("ina238", "ina2xx"):
-                        pw = cls._read_file(f"{base}/power1_input")  # microwatts
-                        if pw and pw.lstrip("-").isdigit():
-                            power_total_mw = float(pw) / 1000.0
-                        break
+                    hwname = (cls._read_file(f"{base}/name") or "").lower()
+                    if hwname not in ("ina238", "ina2xx"):
+                        continue
+                    pw = _num(cls._read_file(f"{base}/power1_input"))
+                    if pw is not None:
+                        power_total_mw = pw / 1000.0
+                    vin = _num(cls._read_file(f"{base}/in1_input"))
+                    if vin is not None:
+                        voltage_V = vin / 1000.0  # mV → V
+                    cur = _num(cls._read_file(f"{base}/curr1_input"))
+                    if cur is not None:
+                        current_A = cur / 1000.0  # mA → A
+                    break
             except OSError:
                 pass
 
         # Die temp from INA238 publisher if available (millidegC → °C)
         temperatures: dict[str, float] = {}
-        temp_mC = cls._read_file(f"{cls._POWER_DIR}/temp_mC")
-        if temp_mC and temp_mC.lstrip("-").isdigit():
-            temperatures["ina238"] = float(temp_mC) / 1000.0
+        temp_mC = _num(cls._read_file(f"{cls._POWER_DIR}/temp_mC"))
+        if temp_mC is not None:
+            temperatures["ina238"] = temp_mC / 1000.0
 
         return {
             "hardware": {
@@ -586,6 +615,8 @@ class ModalixCollector(SystemInfoCollector):
             },
             "power": {
                 "total": power_total_mw,
+                "voltage": voltage_V,
+                "current": current_A,
                 "temperature": temperatures,
             },
         }
@@ -653,6 +684,8 @@ def get_system_info() -> SystemInfo:
             jetson_clocks=None,
             total=float(pw.get("total", 0) or 0),
             temperature=pw.get("temperature") or {},
+            voltage=pw.get("voltage"),
+            current=pw.get("current"),
         )
     elif JetsonCollector.is_jetson():
         device_type = "jetson"

--- a/services/system-manager/system_manager.py
+++ b/services/system-manager/system_manager.py
@@ -500,11 +500,26 @@ class ModalixCollector(SystemInfoCollector):
 
     @staticmethod
     def _read_dt_string(path: str) -> str | None:
+        """First NUL-terminated string (model is a single string)."""
         try:
             with open(path, "rb") as f:
                 return f.read().split(b"\x00")[0].decode("utf-8", errors="replace").strip()
         except OSError:
             return None
+
+    @staticmethod
+    def _read_dt_strings(path: str) -> list[str]:
+        """All NUL-separated strings (compatible is a list)."""
+        try:
+            with open(path, "rb") as f:
+                raw = f.read()
+            return [
+                p.decode("utf-8", errors="replace").strip()
+                for p in raw.split(b"\x00")
+                if p.strip()
+            ]
+        except OSError:
+            return []
 
     @staticmethod
     def _read_file(path: str) -> str | None:
@@ -518,19 +533,16 @@ class ModalixCollector(SystemInfoCollector):
     def get_modalix_info(cls) -> dict[str, Any]:
         """Model/module/serial from DT + AT24CSW unique ID; power from INA238 publisher."""
         model = cls._read_dt_string("/proc/device-tree/model") or "Modalix"
-        compat = cls._read_dt_string("/proc/device-tree/compatible") or ""
+        compat_list = cls._read_dt_strings("/proc/device-tree/compatible")
 
         # Module: prefer SoM token from compatible (e.g. simaai,modalix-som)
         module = "Modalix SoM"
-        for part in re.split(r"[\x00\s]+", compat):
-            p = part.strip()
-            if not p:
-                continue
-            if "modalix-som" in p or p.endswith("modalix-som"):
-                module = p.replace(",", " / ")
+        for p in compat_list:
+            if "modalix-som" in p:
+                module = p  # e.g. simaai,modalix-som
                 break
-            if "modalix" in p and "just" not in p:
-                module = p.replace(",", " / ")
+            if p.startswith("simaai,") and "modalix" in p:
+                module = p
 
         # Serial: ARK JAJ unique ID from AT24CSW010 (ark-jaj-sys-power)
         serial = (

--- a/services/system-manager/system_manager.py
+++ b/services/system-manager/system_manager.py
@@ -70,9 +70,22 @@ class Usage(BaseModel):
     percent: float
 
 
+class DiskVolume(BaseModel):
+    """One physical disk or mounted volume for the Memory/storage card."""
+    name: str          # short label, e.g. eMMC, NVMe, mmcblk0
+    device: str        # /dev/mmcblk0 or /dev/nvme0n1
+    mountpoint: str    # e.g. / or empty if not mounted
+    total: float       # GiB
+    used: float
+    available: float
+    percent: float
+    model: str = ""    # optional drive model string
+
+
 class Resources(BaseModel):
     memory: Usage
-    disk: Usage
+    disk: Usage  # root filesystem (backward compatible)
+    disks: list[DiskVolume] = Field(default_factory=list)
     cpu_count: int
 
 
@@ -140,6 +153,7 @@ class SystemInfoCollector:
                 "available": du.free / (1024**3),
                 "percent": du.percent
             },
+            "disks": SystemInfoCollector.get_disk_volumes(),
             "network_interfaces": {}
         }
 
@@ -168,6 +182,179 @@ class SystemInfoCollector:
             info["codename"] = "unknown"
 
         return info
+
+    @staticmethod
+    def _parent_disk(dev: str) -> str:
+        """/dev/mmcblk0p4 -> mmcblk0; /dev/nvme0n1p1 -> nvme0n1; /dev/sda1 -> sda."""
+        base = os.path.basename(dev)
+        if base.startswith("nvme") and "p" in base[4:]:
+            return re.sub(r"p\d+$", "", base)
+        if re.match(r".*p\d+$", base) and (
+            base.startswith("mmcblk") or base.startswith("sd") or base.startswith("vd")
+        ):
+            return re.sub(r"p\d+$", "", base)
+        m = re.match(r"^(sd[a-z]+|vd[a-z]+|hd[a-z]+)\d+$", base)
+        if m:
+            return m.group(1)
+        return base
+
+    @staticmethod
+    def _disk_label(disk: str, model: str = "") -> str:
+        if disk.startswith("mmcblk"):
+            return "eMMC" if not model else f"eMMC ({model})"
+        if disk.startswith("nvme"):
+            return "NVMe" if not model else f"NVMe ({model.strip()})"
+        if disk.startswith("sd") or disk.startswith("vd"):
+            return model.strip() if model.strip() else disk
+        return disk
+
+    @staticmethod
+    def get_disk_volumes() -> list[dict[str, Any]]:
+        """List physical disks: root usage + any other whole disks (e.g. unmounted NVMe)."""
+        gib = 1024.0 ** 3
+        # parent_disk -> aggregated stats
+        by_disk: dict[str, dict[str, Any]] = {}
+
+        # Mounted real filesystems
+        try:
+            partitions = psutil.disk_partitions(all=False)
+        except Exception:
+            partitions = []
+
+        for part in partitions:
+            dev = part.device or ""
+            if not dev.startswith("/dev/"):
+                continue
+            if any(
+                x in dev
+                for x in ("/loop", "/ram", "/zram", "/dm-", "/mapper/")
+            ):
+                continue
+            fstype = (part.fstype or "").lower()
+            if fstype in ("", "tmpfs", "devtmpfs", "squashfs", "overlay", "proc", "sysfs"):
+                continue
+            try:
+                usage = psutil.disk_usage(part.mountpoint)
+            except OSError:
+                continue
+            parent = SystemInfoCollector._parent_disk(dev)
+            entry = by_disk.setdefault(
+                parent,
+                {
+                    "name": parent,
+                    "device": f"/dev/{parent}",
+                    "mountpoint": "",
+                    "total": 0.0,
+                    "used": 0.0,
+                    "available": 0.0,
+                    "percent": 0.0,
+                    "model": "",
+                    "_root_usage": None,
+                },
+            )
+            # Prefer filesystem stats from "/" for the root disk
+            if part.mountpoint == "/":
+                entry["mountpoint"] = "/"
+                entry["_root_usage"] = usage
+            elif not entry["mountpoint"]:
+                entry["mountpoint"] = part.mountpoint
+                if entry["_root_usage"] is None:
+                    entry["_root_usage"] = usage
+
+        # Whole-disk sizes from sysfs (covers unmounted NVMe etc.)
+        sys_block = "/sys/block"
+        try:
+            block_devs = os.listdir(sys_block)
+        except OSError:
+            block_devs = []
+
+        for disk in sorted(block_devs):
+            if disk.startswith(("loop", "ram", "zram", "dm-", "sr", "fd")):
+                continue
+            if "boot" in disk:  # mmcblk0boot0
+                continue
+            size_path = f"{sys_block}/{disk}/size"
+            try:
+                with open(size_path, "r") as f:
+                    sectors = int(f.read().strip())
+            except (OSError, ValueError):
+                continue
+            total_gib = (sectors * 512) / gib
+            if total_gib < 0.1:
+                continue
+
+            model = ""
+            for mp in (
+                f"{sys_block}/{disk}/device/model",
+                f"{sys_block}/{disk}/device/name",
+            ):
+                try:
+                    with open(mp, "r") as f:
+                        model = f.read().strip()
+                    if model:
+                        break
+                except OSError:
+                    pass
+
+            if disk not in by_disk:
+                by_disk[disk] = {
+                    "name": disk,
+                    "device": f"/dev/{disk}",
+                    "mountpoint": "",
+                    "total": total_gib,
+                    "used": 0.0,
+                    "available": total_gib,
+                    "percent": 0.0,
+                    "model": model,
+                    "_root_usage": None,
+                }
+            else:
+                by_disk[disk]["total"] = total_gib
+                by_disk[disk]["model"] = model or by_disk[disk].get("model", "")
+
+        # Build sorted list: root disk first, then others by name
+        volumes: list[dict[str, Any]] = []
+        for disk, e in by_disk.items():
+            total = float(e.get("total") or 0)
+            usage = e.get("_root_usage")
+            if usage is not None:
+                # Show the mounted filesystem usage (root partition on eMMC)
+                used = usage.used / gib
+                avail = usage.free / gib
+                # Keep device capacity as total when larger (whole eMMC)
+                fs_total = usage.total / gib
+                if total < fs_total:
+                    total = fs_total
+                pct = float(usage.percent)
+                mount = e.get("mountpoint") or ""
+            else:
+                # Unmounted whole disk (e.g. NVMe with old partition table)
+                used = 0.0
+                avail = total
+                pct = 0.0
+                mount = ""
+            if total <= 0:
+                continue
+            volumes.append(
+                {
+                    "name": SystemInfoCollector._disk_label(disk, e.get("model", "")),
+                    "device": e["device"],
+                    "mountpoint": mount,
+                    "total": total,
+                    "used": used,
+                    "available": avail,
+                    "percent": pct,
+                    "model": e.get("model") or "",
+                }
+            )
+
+        def sort_key(v: dict[str, Any]) -> tuple:
+            # Root-bearing disk first
+            is_root = 0 if v.get("mountpoint") == "/" else 1
+            return (is_root, v.get("device") or "")
+
+        volumes.sort(key=sort_key)
+        return volumes
 
     @staticmethod
     def get_temperature_info() -> dict[str, Any]:
@@ -800,6 +987,19 @@ def get_system_info() -> SystemInfo:
                 available=common["disk"]["available"],
                 percent=common["disk"]["percent"],
             ),
+            disks=[
+                DiskVolume(
+                    name=d["name"],
+                    device=d["device"],
+                    mountpoint=d.get("mountpoint") or "",
+                    total=float(d["total"]),
+                    used=float(d["used"]),
+                    available=float(d["available"]),
+                    percent=float(d["percent"]),
+                    model=d.get("model") or "",
+                )
+                for d in (common.get("disks") or [])
+            ],
             cpu_count=common["cpu_count"],
         ),
         network=network,

--- a/services/system-manager/system_manager.py
+++ b/services/system-manager/system_manager.py
@@ -267,12 +267,30 @@ class JetsonCollector(SystemInfoCollector):
 
     @staticmethod
     def is_jetson() -> bool:
-        """Check if running on a Jetson device"""
+        """Check if running on an NVIDIA Jetson (not ARK JAJ + Modalix).
+
+        Note: the carrier product name "Just a Jetson" also contains "jetson";
+        require NVIDIA/Tegra identity so Modalix eLxr is not mis-detected.
+        """
+        if os.path.isfile("/etc/nv_tegra_release"):
+            return True
         try:
-            with open('/proc/device-tree/model', 'r') as f:
+            with open("/proc/device-tree/compatible", "r") as f:
+                compat = f.read().lower()
+            if "simaai" in compat or "modalix" in compat:
+                return False
+            if "nvidia" in compat or "tegra" in compat:
+                return True
+        except OSError:
+            pass
+        try:
+            with open("/proc/device-tree/model", "r") as f:
                 model = f.read().lower()
-                return 'nvidia' in model or 'jetson' in model
-        except:
+            if "modalix" in model or "simaai" in model:
+                return False
+            # Do not match bare "jetson" (carrier product name on Modalix JAJ)
+            return "nvidia" in model or "tegra" in model
+        except OSError:
             return False
 
     @staticmethod
@@ -437,6 +455,130 @@ class GenericLinuxCollector(SystemInfoCollector):
         return info
 
 
+class ModalixCollector(SystemInfoCollector):
+    """Collector for SiMa Modalix (eLxr) on ARK Just a Jetson / Modalix carriers."""
+
+    _POWER_DIR = "/run/ark-jaj/sys-power"
+    _BOARD_DIR = "/run/ark-jaj/board"
+
+    @staticmethod
+    def is_modalix() -> bool:
+        """Detect Modalix SoM / eLxr (not Jetson, not Pi)."""
+        try:
+            if os.path.isfile("/etc/os-release"):
+                with open("/etc/os-release", "r") as f:
+                    osrel = f.read()
+                if re.search(r"^ID=elxr\b", osrel, re.M) or "elxr" in osrel.lower():
+                    return True
+        except OSError:
+            pass
+        try:
+            with open("/proc/device-tree/model", "r") as f:
+                model = f.read().lower()
+            if "modalix" in model:
+                return True
+            # ARK JAJ carrier with Modalix still says "Just a Jetson" in model
+            if "just a jetson" in model and "nvidia" not in model:
+                # Prefer compatible string to avoid false positives
+                try:
+                    with open("/proc/device-tree/compatible", "r") as f:
+                        compat = f.read().lower()
+                    if "modalix" in compat or "simaai" in compat:
+                        return True
+                except OSError:
+                    pass
+        except OSError:
+            pass
+        try:
+            with open("/proc/device-tree/compatible", "r") as f:
+                compat = f.read().lower()
+            if "modalix" in compat or "simaai,modalix" in compat:
+                return True
+        except OSError:
+            pass
+        return False
+
+    @staticmethod
+    def _read_dt_string(path: str) -> str | None:
+        try:
+            with open(path, "rb") as f:
+                return f.read().split(b"\x00")[0].decode("utf-8", errors="replace").strip()
+        except OSError:
+            return None
+
+    @staticmethod
+    def _read_file(path: str) -> str | None:
+        try:
+            with open(path, "r") as f:
+                return f.read().strip()
+        except OSError:
+            return None
+
+    @classmethod
+    def get_modalix_info(cls) -> dict[str, Any]:
+        """Model/module/serial from DT + AT24CSW unique ID; power from INA238 publisher."""
+        model = cls._read_dt_string("/proc/device-tree/model") or "Modalix"
+        compat = cls._read_dt_string("/proc/device-tree/compatible") or ""
+
+        # Module: prefer SoM token from compatible (e.g. simaai,modalix-som)
+        module = "Modalix SoM"
+        for part in re.split(r"[\x00\s]+", compat):
+            p = part.strip()
+            if not p:
+                continue
+            if "modalix-som" in p or p.endswith("modalix-som"):
+                module = p.replace(",", " / ")
+                break
+            if "modalix" in p and "just" not in p:
+                module = p.replace(",", " / ")
+
+        # Serial: ARK JAJ unique ID from AT24CSW010 (ark-jaj-sys-power)
+        serial = (
+            cls._read_file(f"{cls._BOARD_DIR}/unique_id")
+            or cls._read_file(f"{cls._BOARD_DIR}/unique_id_text")
+            or "Not available"
+        )
+
+        # Power: /run/ark-jaj/sys-power from INA238 userspace (or future hwmon)
+        # Frontend expects power.total in milliwatts (Jetson jtop convention).
+        power_total_mw = 0.0
+        power_uW = cls._read_file(f"{cls._POWER_DIR}/power_uW")
+        if power_uW and power_uW.lstrip("-").isdigit():
+            power_total_mw = float(power_uW) / 1000.0
+        else:
+            # Fallback: try in-kernel hwmon ina238 if present
+            try:
+                for name in os.listdir("/sys/class/hwmon"):
+                    base = f"/sys/class/hwmon/{name}"
+                    hwname = cls._read_file(f"{base}/name") or ""
+                    if hwname.lower() in ("ina238", "ina2xx"):
+                        pw = cls._read_file(f"{base}/power1_input")  # microwatts
+                        if pw and pw.lstrip("-").isdigit():
+                            power_total_mw = float(pw) / 1000.0
+                        break
+            except OSError:
+                pass
+
+        # Die temp from INA238 publisher if available (millidegC → °C)
+        temperatures: dict[str, float] = {}
+        temp_mC = cls._read_file(f"{cls._POWER_DIR}/temp_mC")
+        if temp_mC and temp_mC.lstrip("-").isdigit():
+            temperatures["ina238"] = float(temp_mC) / 1000.0
+
+        return {
+            "hardware": {
+                "type": "modalix",
+                "model": model,
+                "module": module,
+                "serial_number": serial,
+            },
+            "power": {
+                "total": power_total_mw,
+                "temperature": temperatures,
+            },
+        }
+
+
 def get_system_info() -> SystemInfo:
     """Collect all system information as a validated SystemInfo model.
 
@@ -471,7 +613,36 @@ def get_system_info() -> SystemInfo:
         temperature={},
     )
 
-    if JetsonCollector.is_jetson():
+    # Modalix first: carrier DT model may include "Just a Jetson" without NVIDIA.
+    if ModalixCollector.is_modalix():
+        device_type = "modalix"
+        mx = ModalixCollector.get_modalix_info()
+        hw = mx.get("hardware", {})
+        hardware = Hardware(
+            type=hw.get("type", "modalix"),
+            model=hw.get("model", "Modalix"),
+            module=hw.get("module", "Modalix SoM"),
+            serial_number=hw.get("serial_number", "Not available"),
+            l4t="",
+            jetpack="",
+        )
+        libraries = Libraries(
+            cuda="",
+            opencv="",
+            opencv_cuda=False,
+            cudnn="",
+            tensorrt="",
+            vpi="",
+            vulkan="",
+        )
+        pw = mx.get("power", {})
+        power = Power(
+            nvpmodel="",
+            jetson_clocks=None,
+            total=float(pw.get("total", 0) or 0),
+            temperature=pw.get("temperature") or {},
+        )
+    elif JetsonCollector.is_jetson():
         device_type = "jetson"
         jetson_data = JetsonCollector.get_jetson_info()
         if jetson_data:
@@ -510,8 +681,23 @@ def get_system_info() -> SystemInfo:
             model=pi_info.get("model", "Raspberry Pi"),
             module="Not available",
             serial_number=pi_info.get("serial_number", "Unknown"),
-            l4t="Not available",
-            jetpack="Not available",
+            l4t="",
+            jetpack="",
+        )
+        libraries = Libraries(
+            cuda="",
+            opencv="",
+            opencv_cuda=False,
+            cudnn="",
+            tensorrt="",
+            vpi="",
+            vulkan="",
+        )
+        power = Power(
+            nvpmodel="",
+            jetson_clocks=None,
+            total=0,
+            temperature={},
         )
     else:
         device_type = "generic"
@@ -520,8 +706,23 @@ def get_system_info() -> SystemInfo:
             model=generic_info.get("cpu_model", "Generic Linux System"),
             module="Not available",
             serial_number="Not available",
-            l4t="Not available",
-            jetpack="Not available",
+            l4t="",
+            jetpack="",
+        )
+        libraries = Libraries(
+            cuda="",
+            opencv="",
+            opencv_cuda=False,
+            cudnn="",
+            tensorrt="",
+            vpi="",
+            vulkan="",
+        )
+        power = Power(
+            nvpmodel="",
+            jetson_clocks=None,
+            total=0,
+            temperature={},
         )
 
     network = Network(
@@ -630,7 +831,9 @@ if __name__ == '__main__':
     print("Device type detection in progress...")
 
     # Quick device detection for startup message
-    if JetsonCollector.is_jetson():
+    if ModalixCollector.is_modalix():
+        print("Detected: SiMa Modalix")
+    elif JetsonCollector.is_jetson():
         print("Detected: NVIDIA Jetson")
     elif RaspberryPiCollector.is_raspberry_pi():
         print("Detected: Raspberry Pi")


### PR DESCRIPTION
## Summary

ARK-OS is a **Debian package** of companion services (mavlink-router, web UI, video, log upload, etc.), not a full OS image. This PR adds a **`modalix`** platform so the same stack can run on **SiMa Modalix + eLxr 12 (aria)** — e.g. **ARK Just a Jetson** with Modalix SoM — after the SiMa base image is flashed.

### How to get it on a Modalix board

1. **Flash base OS** — SiMa Modalix eLxr (meta-ark-simaai / sima-cli netboot), deploy `ark-jaj.dtbo`.
2. **Build the package on arm64** (Python 3.11 host: eLxr aria or Debian bookworm):
   ```bash
   ./packaging/build.sh modalix --version=0.0.0-dev
   ```
   This workstation is **x86_64** — native arm64 binaries/venv must be built on an arm64 runner (CI leg added) or an arm64 machine.
3. **Install on the board** (user **`sima`** must exist):
   ```bash
   sudo ./packaging/install_ark_os.sh --platform=modalix ./ark-os-modalix-bookworm_*.deb
   ```

### Platform differences vs Jetson

| Item | Jetson | Modalix |
|------|--------|---------|
| Service user | `jetson` | **`sima`** |
| Base OS | Ubuntu 22.04 jammy (JP6) | **eLxr 12 aria** (Debian 12 class) |
| jtop / jetson-stats | yes | **no** |
| jetson-can | yes | **no** (no SoM CAN) |
| rid-transmitter | yes | **not packaged yet** |
| FMU reset / VBUS GPIO | Jetson.GPIO board pins | **no-op stubs** until mapped |
| FC link | USB ARK by-id | same USB path when FC is USB |

### Code changes

- `packaging/build.sh` — `modalix` platform, `ARK_USER=sima`, baselines `aria:3.11` / `bookworm:3.11`
- `packaging/assemble_tree.sh`, `build_venv.sh`, `install_ark_os.sh`, `DEBIAN/*`
- `packaging/service-files/modalix/*` — jetson set minus can/rid, `User=sima`
- `platform/modalix/` — README + no-op reset/VBUS helpers
- CI: arm64 `debian:bookworm` matrix leg for `ark-os-modalix-bookworm`

### Test plan

- [ ] CI green for modalix bookworm leg
- [ ] On JAJ+Modalix eLxr: install deb as `sima`, `systemctl status ark-os.target`
- [ ] Web UI loads; mavlink-router finds USB ARK FC if attached
- [ ] Confirm no jetson-can/jtop failures
- [ ] Document any missing JAJ nRESET GPIO for flash-from-UI

### Related

- meta-ark-simaai: base image, `ark-jaj.dtbo`, INA238 `/run/ark-jaj/sys-power`

<img width="1403" height="861" alt="image" src="https://github.com/user-attachments/assets/fee2591a-7d07-42e1-a50a-0045ad4dacbb" />
