### PR TITLE
chore(pointperfect): bump the client to quiet logging and non-interleaved MGA

### DIFF
--- a/packaging/config/pointperfect.toml
+++ b/packaging/config/pointperfect.toml
@@ -34,3 +34,7 @@ use_tls = true
 # provide localized corrections. The position is taken from the autopilot's
 # GPS_RAW_INT messages and sent every 10 seconds.
 send_gga = true
+
+# Log every correction chunk and every forwarded message. Off by default: the
+# client logs a throughput summary every 30 seconds instead.
+verbose = false


### PR DESCRIPTION
## Summary

Bumps `pointperfect-client-mavlink` and adds the `verbose` key to the packaged config.

Depends on ARK-Electronics/pointperfect-client-mavlink#3 — merge that first, then this bump moves to the merged commit.

## Problem

The pointperfect client logged a line per correction chunk, per forwarded MGA message and per `GPS_RTCM_DATA`. Measured on a Jetson against the live NEAR-SPARTN-MGA mountpoint that is 49 lines a minute, which buries the events that matter in the Services page log view and in the journal.

It also forwarded UBX-MGA assistance and corrections in caster stream order, so an assistance frame the caster spliced into the middle of a correction message was injected between the two halves of it. And nothing noticed when the GPS receiver disappeared: the client kept reporting a stale position to the caster and kept forwarding corrections the autopilot discards while its GPS driver re-configures.

## Solution

The bumped client summarizes the stream every 30 seconds, keeps per-message output behind `verbose`, injects assistance and corrections in separate `GPS_RTCM_DATA` sequences, and closes the caster session when GPS_RAW_INT stops — reconnecting when the receiver returns, which is also how it gets a fresh AssistNow burst. The packaged config gains `verbose = false` so the knob is visible in the UI config editor.

On device: 49 log lines/minute before, 2 after, with the assistance burst reported as one block and RTK float retained.