### PR TITLE
feat(jetson): JetPack 7 / Ubuntu 24.04 (noble) package

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -29,6 +29,11 @@ jobs:
             runner: ubuntu-22.04-arm
             container: ""
             extra_deps: "libbluetooth-dev"
+          - platform: jetson
+            codename: noble
+            runner: ubuntu-24.04-arm
+            container: ""
+            extra_deps: "libbluetooth-dev"
           - platform: pi
             codename: bookworm
             runner: ubuntu-22.04-arm
@@ -45,6 +50,7 @@ jobs:
     # from the *system* python at runtime — a Jammy (3.10) venv will not run on
     # Bookworm (no system python3.10) and vice-versa.
     #   - jetson: ubuntu-22.04-arm natively    (Jammy / Python 3.10  = JetPack 6 rootfs)
+    #   - jetson: ubuntu-24.04-arm natively    (Noble / Python 3.12  = JetPack 7 rootfs)
     #   - pi:     a debian:bookworm container  (Debian 12 / Python 3.11 = Raspberry Pi OS Bookworm)
     #   - pi:     a debian:trixie   container  (Debian 13 / Python 3.13 = Raspberry Pi OS Trixie)
     # The container runs on the same arm64 host. Each leg's `codename` (the host's OS

--- a/README.md
+++ b/README.md
@@ -39,23 +39,31 @@ cd ARK-OS
 sudo ./packaging/install_ark_os.sh --ark-os-version=X.Y.Z
 
 # ...or install a .deb you already have (built locally or downloaded):
-sudo ./packaging/install_ark_os.sh ./ark-os-jetson-jammy_X.Y.Z_arm64.deb
+sudo ./packaging/install_ark_os.sh ./ark-os-jetson-jammy_X.Y.Z_arm64.deb   # JetPack 6
+sudo ./packaging/install_ark_os.sh ./ark-os-jetson-noble_X.Y.Z_arm64.deb   # JetPack 7
 ```
 
 The script auto-detects Jetson vs Pi (override with `--platform`), skips jtop when it is already at the pinned version, and re-runs safely for updates. The versions it installs are pinned in `packaging/versions.env`. Run `sudo ./packaging/install_ark_os.sh --help` for all options.
 
 ### Manual install
 
-MAVSDK is bundled inside the ARK-OS package, so you only install ARK-OS itself. Replace `<ark-os-ver>` and `<jetson-stats-ver>` with the versions pinned in `packaging/versions.env`. The ARK-OS package name includes your OS release codename — `jammy` for JetPack 6, `trixie` for Raspberry Pi OS (Debian 13) or `bookworm` (Debian 12) — so pick the asset matching your device's `/etc/os-release` `VERSION_CODENAME`.
+MAVSDK is bundled inside the ARK-OS package, so you only install ARK-OS itself. Replace `<ark-os-ver>` and `<jetson-stats-ver>` with the versions pinned in `packaging/versions.env`. The ARK-OS package name includes your OS release codename — `jammy` for JetPack 6 (Ubuntu 22.04), `noble` for JetPack 7 (Ubuntu 24.04), `trixie` for Raspberry Pi OS (Debian 13) or `bookworm` (Debian 12) — so pick the asset matching your device's `/etc/os-release` `VERSION_CODENAME`.
 
 #### Jetson
 ```
+# JetPack 6 (Ubuntu 22.04 / jammy)
 wget https://github.com/ARK-Electronics/ARK-OS/releases/download/v<ark-os-ver>/ark-os-jetson-jammy_<ark-os-ver>_arm64.deb
-
 sudo apt install ./ark-os-jetson-jammy_<ark-os-ver>_arm64.deb
 
+# JetPack 7 (Ubuntu 24.04 / noble)
+wget https://github.com/ARK-Electronics/ARK-OS/releases/download/v<ark-os-ver>/ark-os-jetson-noble_<ark-os-ver>_arm64.deb
+sudo apt install ./ark-os-jetson-noble_<ark-os-ver>_arm64.deb
+
 # Recommended: jtop, for Jetson system stats in the web UI
-sudo apt install -y python3-pip && sudo pip3 install "jetson-stats==<jetson-stats-ver>"
+# Ubuntu 24.04 needs --break-system-packages (PEP 668); harmless on 22.04 if omitted
+# after `apt install python3-pip`.
+sudo apt install -y python3-pip python3-setuptools
+sudo pip3 install --break-system-packages "jetson-stats==<jetson-stats-ver>"
 ```
 
 #### Raspberry Pi

--- a/packaging/assemble_tree.sh
+++ b/packaging/assemble_tree.sh
@@ -140,9 +140,10 @@ else
 fi
 chmod 0644 "$SMR"
 
-# --- service-manager polkit pkla: the JetPack-6 / Ubuntu 22.04 rootfs runs polkit
-# 0.105, which honors .pkla (local authority) and ignores JS .rules; Pi/Bookworm is
-# the reverse. Ship both so the grant applies on each. pkla can't scope per-unit, so
+# --- service-manager polkit pkla: JetPack 6 / Ubuntu 22.04 runs polkit 0.105,
+# which honors .pkla and ignores JS .rules. JetPack 7 / Ubuntu 24.04 is polkit
+# 124 and Pi/Bookworm are the reverse (JS .rules, no pkla). Ship both so the
+# grant applies on each. pkla can't scope per-unit, so
 # it grants the service user blanket systemd manage rights (same breadth as the
 # NetworkManager grant above); the .rules file keeps per-unit scoping where honored.
 SMPKLA="$PKG/etc/polkit-1/localauthority/90-mandatory.d/99-ark-service-manager.pkla"

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -68,7 +68,7 @@ fi
 # new OS release = add an entry here and a matching leg to the CI build matrix
 # (.github/workflows/build-deb.yml).
 case "$PLATFORM" in
-    jetson) BASELINES="jammy:3.10 noble:3.12" ;;     # JetPack 6 / JetPack 7 (noble = future, untested)
+    jetson) BASELINES="jammy:3.10 noble:3.12" ;;     # JetPack 6 (22.04) / JetPack 7 (24.04)
     pi)     BASELINES="bookworm:3.11 trixie:3.13" ;;  # Debian 12 (Pi OS Bookworm) / Debian 13 (Pi OS Trixie)
 esac
 

--- a/packaging/build_venv.sh
+++ b/packaging/build_venv.sh
@@ -2,7 +2,8 @@
 # Create the Python virtualenv AT ITS FINAL INSTALL PATH so that shebangs and
 # pyvenv.cfg resolve correctly on the device, then move it into the package tree.
 # The build host must be arm64 with the target's system Python: 3.10 for jetson
-# (JetPack 6 / Jammy) or, for pi, 3.11 on Bookworm / 3.13 on Trixie (Raspberry Pi OS).
+# on Jammy (JetPack 6) or 3.12 on Noble (JetPack 7); for pi, 3.11 on Bookworm /
+# 3.13 on Trixie (Raspberry Pi OS).
 # build.sh enforces this baseline. Invoked by build.sh.
 set -euo pipefail
 

--- a/packaging/install_ark_os.sh
+++ b/packaging/install_ark_os.sh
@@ -52,9 +52,9 @@ Positional:
 
 Options:
   --platform=jetson|pi      Override platform autodetection.
-  --codename=NAME           Override OS-release codename autodetection (bookworm, trixie,
-                            jammy, …). Only needed to name a download when /etc/os-release
-                            can't be read.
+  --codename=NAME           Override OS-release codename autodetection (jammy, noble,
+                            bookworm, trixie, …). Only needed to name a download when
+                            /etc/os-release can't be read.
   --ark-os-version=X.Y.Z    Download this ark-os release when no local deb is given.
   --jetson-stats-version=X  Override the jetson-stats version (default from versions.env).
   --skip-jtop               Do not install jetson-stats (Jetson only).
@@ -142,9 +142,20 @@ fetch() {
 # install over a newer one (version testing/rollback), which apt refuses by default.
 apt_install_deb() { apt-get install -y --allow-downgrades "$(readlink -f "$1")"; }
 
+# Ubuntu 24.04 (JetPack 7 / noble) marks the system Python as EXTERNALLY-MANAGED
+# (PEP 668). jtop must still be a *system* install so the bundled venv can import
+# it via system-site-packages; --break-system-packages is the matching flag.
+pip_install() {
+    local flags=()
+    if ls /usr/lib/python3*/EXTERNALLY-MANAGED >/dev/null 2>&1; then
+        flags+=(--break-system-packages)
+    fi
+    pip3 install "${flags[@]}" "$@"
+}
+
 install_jtop() {
-    apt-get install -y python3-pip || return 1
-    pip3 install "jetson-stats==$JETSON_STATS_VERSION" || return 1
+    apt-get install -y python3-pip python3-setuptools || return 1
+    pip_install "jetson-stats==$JETSON_STATS_VERSION" || return 1
     # Bring the jtop daemon up now (pip's setup.py installs the unit) and enable
     # it for next boot; harmless if already active.
     systemctl enable --now jtop.service 2>/dev/null || true
@@ -192,7 +203,7 @@ else
     elif [ "${#matches[@]}" -gt 1 ]; then
         die "multiple ark-os-${PLATFORM} debs in $(pwd); pass the one to install as an argument."
     elif [ -n "$ARK_OS_VERSION" ]; then
-        [ -n "$CODENAME" ] || die "could not determine this device's OS codename to name the download; pass --codename=<bookworm|trixie|jammy|…>."
+        [ -n "$CODENAME" ] || die "could not determine this device's OS codename to name the download; pass --codename=<jammy|noble|bookworm|trixie|…>."
         ARK_OS_DEB="$DL_DIR/ark-os-${PLATFORM}-${CODENAME}_${ARK_OS_VERSION}_arm64.deb"
         fetch "$ARK_OS_REPO/releases/download/v${ARK_OS_VERSION}/$(basename "$ARK_OS_DEB")" "$ARK_OS_DEB"
     else
@@ -220,7 +231,7 @@ if [ "$PLATFORM" = "jetson" ] && [ "$SKIP_JTOP" -eq 0 ]; then
             info "jetson-stats $JETSON_STATS_VERSION installed."
         else
             warn "jetson-stats install failed — Jetson stats in the web UI will be unavailable."
-            warn "  retry later with: sudo pip3 install \"jetson-stats==${JETSON_STATS_VERSION}\""
+            warn "  retry later with: sudo pip3 install --break-system-packages \"jetson-stats==${JETSON_STATS_VERSION}\""
         fi
     fi
 fi

--- a/packaging/install_ark_os.sh
+++ b/packaging/install_ark_os.sh
@@ -156,8 +156,11 @@ pip_install() {
 install_jtop() {
     apt-get install -y python3-pip python3-setuptools || return 1
     pip_install "jetson-stats==$JETSON_STATS_VERSION" || return 1
-    # Bring the jtop daemon up now (pip's setup.py installs the unit) and enable
-    # it for next boot; harmless if already active.
+    # 7.x ships the unit under /usr/local/share/jetson_stats and installs it
+    # with `jtop --install-service`. Older 4.x wrote jtop.service from setup.py.
+    if command -v jtop >/dev/null 2>&1; then
+        jtop --install-service || true
+    fi
     systemctl enable --now jtop.service 2>/dev/null || true
     return 0
 }

--- a/packaging/versions.env
+++ b/packaging/versions.env
@@ -24,7 +24,10 @@ MAVSDK_VERSION="3.17.1"
 # jetson-stats (jtop). Installed system-wide on Jetson so system-manager's jtop
 # client can report Jetson stats to the web UI. Not an apt Depends and not in the
 # bundled venv (the venv imports it via system-site-packages — see build_venv.sh).
-JETSON_STATS_VERSION="4.3.2"
+# 7.2.1 is the first release that maps L4T R39.2.1 / JetPack 7.2.1 and includes
+# the Orin JP7 GPU/tegrastats fixes. Keep this in sync with
+# ark_jetson_kernel/versions.env.
+JETSON_STATS_VERSION="7.2.1"
 
 # Node.js runtime bundled into the package (build-time only).
 NODE_VERSION="20.20.2"

--- a/platform/jetson/scripts/extras/README.md
+++ b/platform/jetson/scripts/extras/README.md
@@ -12,7 +12,7 @@ that would be expensive to rediscover.
 | Script | What it does |
 |---|---|
 | `install_opencv.sh` | Builds/installs OpenCV with CUDA support on a Jetson dev box. |
-| `install_ros2.sh` | Installs ROS 2 on a dev box. |
+| `install_ros2.sh` | Installs ROS 2 Humble on a JetPack 6 / Jammy dev box. Refuses JetPack 7 (use Jazzy). |
 | `i2s_gpio_example.py` | Example: drive the Jetson I2S/GPIO pins. |
 | `icm42688p_test.py` | Read the ICM-42688-P IMU over SPI: full-screen live view by default, `--raw` for a JSON stream. |
 | `ina238_test.py` | Example: read the INA238 power monitor over I2C/SMBus. |

--- a/platform/jetson/scripts/extras/install_ros2.sh
+++ b/platform/jetson/scripts/extras/install_ros2.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+# Dev extra: ROS 2 Humble + the JP6 workspace. Humble has no noble packages;
+# on JetPack 7 / Ubuntu 24.04 use ROS 2 Jazzy instead and do not clone
+# ros2_jetpack6_ws.
+if [ -r /etc/os-release ]; then
+    # shellcheck source=/dev/null
+    . /etc/os-release
+    if [ "${VERSION_CODENAME:-}" = "noble" ]; then
+        echo "ERROR: extras/install_ros2.sh installs ROS 2 Humble (Jammy / JetPack 6)." >&2
+        echo "       JetPack 7 is Ubuntu 24.04 — install ROS 2 Jazzy by hand." >&2
+        exit 1
+    fi
+fi
 sudo apt update
 sudo apt-get install software-properties-common
 sudo add-apt-repository universe

--- a/platform/jetson/scripts/l4t_compat.py
+++ b/platform/jetson/scripts/l4t_compat.py
@@ -1,0 +1,30 @@
+"""L4T / JetPack helpers shared by the Jetson GPIO operator scripts."""
+
+from __future__ import annotations
+
+import re
+
+_NV_TEGRA_RELEASE = "/etc/nv_tegra_release"
+
+
+def l4t_release() -> int | None:
+    """Return the L4T major release (36, 39, ...) or None if unknown."""
+    try:
+        with open(_NV_TEGRA_RELEASE) as f:
+            text = f.read()
+    except OSError:
+        return None
+    match = re.search(r"\bR(\d+)\b", text)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def vbus_is_pinmuxed() -> bool:
+    """True when VBUS_DET is owned by the pinmux, not GPIO.
+
+    JetPack 6 (R36) and later ARK device trees pinmux VBUS_DET, so driving
+    board pin 32 as GPIO fails or fights the pinmux. Pre-R36 still uses GPIO.
+    """
+    release = l4t_release()
+    return release is not None and release >= 36

--- a/platform/jetson/scripts/reset_fmu_fast.py
+++ b/platform/jetson/scripts/reset_fmu_fast.py
@@ -20,8 +20,9 @@
 # DEALINGS IN THE SOFTWARE.
 
 import Jetson.GPIO as GPIO
-import os
 import time
+
+from l4t_compat import vbus_is_pinmuxed
 
 # Pin definitions at:
 # ark_jetson_orin_nano_nx_device_tree/Linux_for_Tegra/source/hardware/nvidia/
@@ -29,22 +30,18 @@ import time
 
 reset_pin = 33
 vbus_det_pin = 32
-jetpack_6 = False
 
 def main():
-    # Check Jetpack version. R36 can't use VBUS Enable
-    with open("/etc/nv_tegra_release") as f:
-        jetpack_version = f.read()
-    if "R36" in jetpack_version:
-        print("Jetpack version is R36, skipping VBUS Control")
-        jetpack_6 = True
+    # R36+ (JP6 / JP7) pinmuxes VBUS_DET; do not drive it as GPIO.
+    skip_vbus = vbus_is_pinmuxed()
+    if skip_vbus:
+        print("L4T R36+ pinmuxes VBUS_DET, skipping VBUS GPIO control")
 
     # Configure reset
     GPIO.setmode(GPIO.BOARD) # Jetson board numbering scheme
     GPIO.setup(reset_pin, GPIO.OUT, initial=GPIO.HIGH)
 
-    # Configure VBUS_DET if not JP6 -- configured in pinmux in JP6
-    if not jetpack_6:
+    if not skip_vbus:
         GPIO.setup(vbus_det_pin, GPIO.OUT, initial=GPIO.HIGH)
         # Disable vbus detect for a faster reset
         GPIO.output(vbus_det_pin, GPIO.LOW)
@@ -56,7 +53,7 @@ def main():
     time.sleep(0.1)
     GPIO.output(reset_pin, GPIO.LOW)
 
-    if not jetpack_6:
+    if not skip_vbus:
         # Do not enable VBUS, skips bootloader
         time.sleep(1)
         GPIO.output(vbus_det_pin, GPIO.HIGH)

--- a/platform/jetson/scripts/reset_fmu_wait_bl.py
+++ b/platform/jetson/scripts/reset_fmu_wait_bl.py
@@ -20,8 +20,9 @@
 # DEALINGS IN THE SOFTWARE.
 
 import Jetson.GPIO as GPIO
-import os
 import time
+
+from l4t_compat import vbus_is_pinmuxed
 
 # Pin definitions at:
 # ark_jetson_orin_nano_nx_device_tree/Linux_for_Tegra/source/hardware/nvidia/
@@ -29,22 +30,18 @@ import time
 
 reset_pin = 33
 vbus_det_pin = 32
-jetpack_6 = False
 
 def main():
-    # Check Jetpack version. R36 can't use VBUS Enable
-    with open("/etc/nv_tegra_release") as f:
-        jetpack_version = f.read()
-    if "R36" in jetpack_version:
-        print("Jetpack version is R36, skipping VBUS Control")
-        jetpack_6 = True
+    # R36+ (JP6 / JP7) pinmuxes VBUS_DET; do not drive it as GPIO.
+    skip_vbus = vbus_is_pinmuxed()
+    if skip_vbus:
+        print("L4T R36+ pinmuxes VBUS_DET, skipping VBUS GPIO control")
 
     # Configure reset
     GPIO.setmode(GPIO.BOARD)
     GPIO.setup(reset_pin, GPIO.OUT, initial=GPIO.HIGH)
 
-    # Configure VBUS_DET if not JP6 -- configured in pinmux in JP6
-    if not jetpack_6:
+    if not skip_vbus:
         GPIO.setup(vbus_det_pin, GPIO.OUT, initial=GPIO.HIGH)
 
     print("Resetting Flight Controller!")
@@ -54,8 +51,8 @@ def main():
     time.sleep(0.1)
     GPIO.output(reset_pin, GPIO.LOW)
 
-    if not jetpack_6:
-        # Enable VBUS immediatly to catch bootloader and wait
+    if not skip_vbus:
+        # Enable VBUS immediately to catch bootloader and wait
         GPIO.output(vbus_det_pin, GPIO.HIGH)
 
 if __name__ == '__main__':

--- a/platform/jetson/scripts/vbus_disable.py
+++ b/platform/jetson/scripts/vbus_disable.py
@@ -20,8 +20,9 @@
 # DEALINGS IN THE SOFTWARE.
 
 import Jetson.GPIO as GPIO
-import os
 import time
+
+from l4t_compat import vbus_is_pinmuxed
 
 # Pin definitions at:
 # ark_jetson_orin_nano_nx_device_tree/Linux_for_Tegra/source/hardware/nvidia/
@@ -30,11 +31,9 @@ import time
 vbus_det_pin = 32
 
 def main():
-    # Check Jetpack version. R36 can't use VBUS Enable
-    with open("/etc/nv_tegra_release") as f:
-        jetpack_version = f.read()
-    if "R36" in jetpack_version:
-        print("Jetpack version is R36, skipping VBUS Disable")
+    # R36+ (JP6 / JP7) pinmuxes VBUS_DET; do not drive it as GPIO.
+    if vbus_is_pinmuxed():
+        print("L4T R36+ pinmuxes VBUS_DET, skipping VBUS Disable")
         return
 
     # Configure VBUS_SENSE_BOOTLOADER

--- a/platform/jetson/scripts/vbus_enable.py
+++ b/platform/jetson/scripts/vbus_enable.py
@@ -20,8 +20,9 @@
 # DEALINGS IN THE SOFTWARE.
 
 import Jetson.GPIO as GPIO
-import os
 import time
+
+from l4t_compat import vbus_is_pinmuxed
 
 # Pin definitions at:
 # ark_jetson_orin_nano_nx_device_tree/Linux_for_Tegra/source/hardware/nvidia/
@@ -30,11 +31,9 @@ import time
 vbus_det_pin = 32
 
 def main():
-    # Check Jetpack version. R36 can't use VBUS Enable
-    with open("/etc/nv_tegra_release") as f:
-        jetpack_version = f.read()
-    if "R36" in jetpack_version:
-        print("Jetpack version is R36, skipping VBUS Enable")
+    # R36+ (JP6 / JP7) pinmuxes VBUS_DET; do not drive it as GPIO.
+    if vbus_is_pinmuxed():
+        print("L4T R36+ pinmuxes VBUS_DET, skipping VBUS Enable")
         return
 
     # Configure VBUS_SENSE_BOOTLOADER


### PR DESCRIPTION
## Why

[ark_jetson_kernel#109](https://github.com/ARK-Electronics/ark_jetson_kernel/pull/109) flashes JetPack 7.2.1 / L4T R39.2.1 (Ubuntu 24.04 noble). `provision.sh` there cannot install ARK-OS because only `ark-os-jetson-jammy` is published, and a jammy venv will not run on noble's Python 3.12.

`packaging/build.sh` already listed `noble:3.12` as a jetson baseline, marked untested. This makes it real.

## What

- CI: add a `jetson` / `noble` matrix leg on `ubuntu-24.04-arm` so PRs and tags produce `ark-os-jetson-noble_<ver>_arm64.deb`.
- `install_ark_os.sh`: detect PEP 668 (`EXTERNALLY-MANAGED`) and pass `--break-system-packages` so jtop can still be a system install on 24.04.
- Pin `JETSON_STATS_VERSION` to **7.2.1** (maps L4T R39.2.1 / JP 7.2.1, includes the Orin JP7 GPU/tegrastats fixes). 4.3.2 reports Jetpack as not detected on JP7.
- GPIO helpers: VBUS_DET is pinmuxed on L4T **R36 and later** (JP6 and JP7), not only when the string `R36` appears. Shared helper `l4t_compat.py`.
- Docs: jammy = JetPack 6, noble = JetPack 7. `extras/install_ros2.sh` refuses noble (Humble is Jammy-only; use Jazzy).

The jammy (JetPack 6) package path is unchanged.

## Follow-up in ark_jetson_kernel

Once CI attaches a noble deb (PR artifact, or a `draft-*` / `v*` release):

- `provision.sh` currently hardcodes `ark-os-jetson-jammy` and only searches that prefix on fallback.
- Point JP7 images at `ark-os-jetson-noble` and bump `JETSON_STATS_VERSION` to 7.2.1 to match `packaging/versions.env`.

## Tested

- `l4t_compat` parse of R35 / R36 / R39 (R35 still drives VBUS as GPIO; R36+ skip).
- Live JP7 PAB V3 (`# R39 (release), REVISION: 2.1`, Ubuntu 24.04.4, Python 3.12.3): PEP 668 present, polkit 124, `libssl3t64`, gpiochip/i2c/can present. Full `.deb` install waits on the noble CI artifact.